### PR TITLE
Added stdbool.h to nrf52 plaform

### DIFF
--- a/mjs.c
+++ b/mjs.c
@@ -1165,6 +1165,7 @@ int gettimeofday(struct timeval *tp, void *tzp);
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
+#include <stdbool.h>
 
 #define to64(x) strtoll(x, NULL, 10)
 


### PR DESCRIPTION
The includes for nrf52 was missing stdbool.h, shows up in other packages like ESP32 / TI / others.

Because the platform guesser does not attempt to recognize the nrf52, the project needs a define of CS_PLATFORM=CS_P_NRF52