### PR TITLE
docs: Working URL for intro article

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ implements a strict subset of ES6 (JavaScript version 6):
 - Any valid ES6 code is not necessarily a valid mJS code.
 
 On 32-bit ARM mJS engine takes about 50k of flash memory, and less than 1k
-of RAM (see [intro article](http://goo.gl/zJYyWF)).
+of RAM (see [intro article](https://mongoose-os.com/blog/mjs-a-new-approach-to-embedded-scripting/)).
 mJS is part of [MongooseOS](https://mongoose-os.com), 
 where it enables scripting for IoT devices.
 


### PR DESCRIPTION
Hello,

This pull request makes a tiny update in `README.md` to provide a working URL of the intro article, [mJS - a new approach to embedded scripting](https://mongoose-os.com/blog/mjs-a-new-approach-to-embedded-scripting/).

Since the URL led to a 404 page before, I found the article by searching for some keywords; it's a nice introduction so I thought others might benefit from it.

I'm happy to discover this `mjs` project, and looking forward to exploring how to use it.
