### PR TITLE
Add mjs_no_common.c

### DIFF
--- a/mjs.h
+++ b/mjs.h
@@ -1,6 +1,21 @@
-#ifdef MJS_MODULE_LINES
-#line 1 "src/mjs_license.h"
-#endif
+/*
+ * Copyright (c) 2017 Cesanta Software Limited
+ * All rights reserved
+ *
+ * This software is dual-licensed: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation. For the terms of this
+ * license, see <http://www.gnu.org/licenses/>.
+ *
+ * You are free to use this software under the terms of the GNU General
+ * Public License, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Alternatively, you can license this software under a commercial
+ * license, as set out in <https://www.cesanta.com/license>.
+ */
+
 #ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_features.h"
 #endif
@@ -49,7 +64,6 @@ typedef unsigned char uint8_t;
 #endif
 #include <stdio.h>
 #include <stddef.h>
-/* Amalgamated: #include "mjs_license.h" */
 /* Amalgamated: #include "mjs_features.h" */
 
 #if defined(__cplusplus)
@@ -302,7 +316,6 @@ void mjs_set_ffi_resolver(struct mjs *mjs, mjs_ffi_resolver_t *dlsym);
 #endif /* __cplusplus */
 
 #endif /* MJS_FFI_PUBLIC_H_ */
-#ifndef MJS_EXPORT_INTERNAL_HEADERS
 #ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_array_public.h"
 #endif
@@ -366,7 +379,6 @@ typedef unsigned char uint8_t;
 #endif
 #include <stdio.h>
 #include <stddef.h>
-/* Amalgamated: #include "mjs_license.h" */
 /* Amalgamated: #include "mjs_features.h" */
 
 #if defined(__cplusplus)
@@ -1017,4 +1029,3 @@ int mjs_get_offset_by_call_frame_num(struct mjs *mjs, int cf_num);
 #endif /* __cplusplus */
 
 #endif /* MJS_UTIL_PUBLIC_H_ */
-#endif /* MJS_EXPORT_INTERNAL_HEADERS */

--- a/mjs_no_common.c
+++ b/mjs_no_common.c
@@ -18,2526 +18,13 @@
 
 #include "mjs.h"
 #ifdef MJS_MODULE_LINES
-#line 1 "src/common/platform.h"
-#endif
-#ifndef CS_COMMON_PLATFORM_H_
-#define CS_COMMON_PLATFORM_H_
-
-/*
- * For the "custom" platform, includes and dependencies can be
- * provided through mg_locals.h.
- */
-#define CS_P_CUSTOM 0
-#define CS_P_UNIX 1
-#define CS_P_WINDOWS 2
-#define CS_P_ESP32 15
-#define CS_P_ESP8266 3
-#define CS_P_CC3100 6
-#define CS_P_CC3200 4
-#define CS_P_CC3220 17
-#define CS_P_MSP432 5
-#define CS_P_TM4C129 14
-#define CS_P_MBED 7
-#define CS_P_WINCE 8
-#define CS_P_NXP_LPC 13
-#define CS_P_NXP_KINETIS 9
-#define CS_P_NRF51 12
-#define CS_P_NRF52 10
-#define CS_P_PIC32 11
-#define CS_P_RS14100 18
-#define CS_P_STM32 16
-/* Next id: 19 */
-
-/* If not specified explicitly, we guess platform by defines. */
-#ifndef CS_PLATFORM
-
-#if defined(TARGET_IS_MSP432P4XX) || defined(__MSP432P401R__)
-#define CS_PLATFORM CS_P_MSP432
-#elif defined(cc3200) || defined(TARGET_IS_CC3200)
-#define CS_PLATFORM CS_P_CC3200
-#elif defined(cc3220) || defined(TARGET_IS_CC3220)
-#define CS_PLATFORM CS_P_CC3220
-#elif defined(__unix__) || defined(__APPLE__)
-#define CS_PLATFORM CS_P_UNIX
-#elif defined(WINCE)
-#define CS_PLATFORM CS_P_WINCE
-#elif defined(_WIN32)
-#define CS_PLATFORM CS_P_WINDOWS
-#elif defined(__MBED__)
-#define CS_PLATFORM CS_P_MBED
-#elif defined(__USE_LPCOPEN)
-#define CS_PLATFORM CS_P_NXP_LPC
-#elif defined(FRDM_K64F) || defined(FREEDOM)
-#define CS_PLATFORM CS_P_NXP_KINETIS
-#elif defined(PIC32)
-#define CS_PLATFORM CS_P_PIC32
-#elif defined(ESP_PLATFORM)
-#define CS_PLATFORM CS_P_ESP32
-#elif defined(ICACHE_FLASH)
-#define CS_PLATFORM CS_P_ESP8266
-#elif defined(TARGET_IS_TM4C129_RA0) || defined(TARGET_IS_TM4C129_RA1) || \
-    defined(TARGET_IS_TM4C129_RA2)
-#define CS_PLATFORM CS_P_TM4C129
-#elif defined(RS14100)
-#define CS_PLATFORM CS_P_RS14100
-#elif defined(STM32)
-#define CS_PLATFORM CS_P_STM32
-#endif
-
-#ifndef CS_PLATFORM
-#error "CS_PLATFORM is not specified and we couldn't guess it."
-#endif
-
-#endif /* !defined(CS_PLATFORM) */
-
-#define MG_NET_IF_SOCKET 1
-#define MG_NET_IF_SIMPLELINK 2
-#define MG_NET_IF_LWIP_LOW_LEVEL 3
-#define MG_NET_IF_PIC32 4
-#define MG_NET_IF_NULL 5
-
-#define MG_SSL_IF_OPENSSL 1
-#define MG_SSL_IF_MBEDTLS 2
-#define MG_SSL_IF_SIMPLELINK 3
-
-/* Amalgamated: #include "common/platforms/platform_unix.h" */
-/* Amalgamated: #include "common/platforms/platform_windows.h" */
-/* Amalgamated: #include "common/platforms/platform_esp32.h" */
-/* Amalgamated: #include "common/platforms/platform_esp8266.h" */
-/* Amalgamated: #include "common/platforms/platform_cc3100.h" */
-/* Amalgamated: #include "common/platforms/platform_cc3200.h" */
-/* Amalgamated: #include "common/platforms/platform_cc3220.h" */
-/* Amalgamated: #include "common/platforms/platform_mbed.h" */
-/* Amalgamated: #include "common/platforms/platform_nrf51.h" */
-/* Amalgamated: #include "common/platforms/platform_nrf52.h" */
-/* Amalgamated: #include "common/platforms/platform_wince.h" */
-/* Amalgamated: #include "common/platforms/platform_nxp_lpc.h" */
-/* Amalgamated: #include "common/platforms/platform_nxp_kinetis.h" */
-/* Amalgamated: #include "common/platforms/platform_pic32.h" */
-/* Amalgamated: #include "common/platforms/platform_rs14100.h" */
-/* Amalgamated: #include "common/platforms/platform_stm32.h" */
-#if CS_PLATFORM == CS_P_CUSTOM
-#include <platform_custom.h>
-#endif
-
-/* Common stuff */
-
-#if !defined(PRINTF_LIKE)
-#if defined(__GNUC__) || defined(__clang__) || defined(__TI_COMPILER_VERSION__)
-#define PRINTF_LIKE(f, a) __attribute__((format(printf, f, a)))
-#else
-#define PRINTF_LIKE(f, a)
-#endif
-#endif
-
-#if !defined(WEAK)
-#if (defined(__GNUC__) || defined(__clang__) || \
-     defined(__TI_COMPILER_VERSION__)) &&       \
-    !defined(_WIN32)
-#define WEAK __attribute__((weak))
-#else
-#define WEAK
-#endif
-#endif
-
-#ifdef __GNUC__
-#define NORETURN __attribute__((noreturn))
-#define NOINLINE __attribute__((noinline))
-#define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#define NOINSTR __attribute__((no_instrument_function))
-#define DO_NOT_WARN_UNUSED __attribute__((unused))
-#else
-#define NORETURN
-#define NOINLINE
-#define WARN_UNUSED_RESULT
-#define NOINSTR
-#define DO_NOT_WARN_UNUSED
-#endif /* __GNUC__ */
-
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-#endif
-
-#endif /* CS_COMMON_PLATFORM_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_windows.h"
-#endif
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_WINDOWS_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_WINDOWS_H_
-#if CS_PLATFORM == CS_P_WINDOWS
-
-/*
- * MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
- * MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
- * MSVC++ 11.0 _MSC_VER == 1700 (Visual Studio 2012)
- * MSVC++ 10.0 _MSC_VER == 1600 (Visual Studio 2010)
- * MSVC++ 9.0  _MSC_VER == 1500 (Visual Studio 2008)
- * MSVC++ 8.0  _MSC_VER == 1400 (Visual Studio 2005)
- * MSVC++ 7.1  _MSC_VER == 1310 (Visual Studio 2003)
- * MSVC++ 7.0  _MSC_VER == 1300
- * MSVC++ 6.0  _MSC_VER == 1200
- * MSVC++ 5.0  _MSC_VER == 1100
- */
-#ifdef _MSC_VER
-#pragma warning(disable : 4127) /* FD_SET() emits warning, disable it */
-#pragma warning(disable : 4204) /* missing c99 support */
-#endif
-
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS 1
-#endif
-
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
-#include <assert.h>
-#include <direct.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <io.h>
-#include <limits.h>
-#include <signal.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <time.h>
-#include <ctype.h>
-
-#ifdef _MSC_VER
-#pragma comment(lib, "ws2_32.lib") /* Linking with winsock library */
-#endif
-
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <windows.h>
-#include <process.h>
-
-#if defined(_MSC_VER) && (_MSC_VER < 1700)
-typedef int bool;
-#else
-#include <stdbool.h>
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER >= 1800
-#define strdup _strdup
-#endif
-
-#ifndef EINPROGRESS
-#define EINPROGRESS WSAEINPROGRESS
-#endif
-#ifndef EWOULDBLOCK
-#define EWOULDBLOCK WSAEWOULDBLOCK
-#endif
-#ifndef __func__
-#define STRX(x) #x
-#define STR(x) STRX(x)
-#define __func__ __FILE__ ":" STR(__LINE__)
-#endif
-#define snprintf _snprintf
-#define vsnprintf _vsnprintf
-#define to64(x) _atoi64(x)
-#if !defined(__MINGW32__) && !defined(__MINGW64__)
-#define popen(x, y) _popen((x), (y))
-#define pclose(x) _pclose(x)
-#define fileno _fileno
-#endif
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-#define fseeko(x, y, z) _fseeki64((x), (y), (z))
-#else
-#define fseeko(x, y, z) fseek((x), (y), (z))
-#endif
-#if defined(_MSC_VER) && _MSC_VER <= 1200
-typedef unsigned long uintptr_t;
-typedef long intptr_t;
-#endif
-typedef int socklen_t;
-#if _MSC_VER >= 1700
-#include <stdint.h>
-#else
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef int int32_t;
-typedef unsigned int uint32_t;
-typedef short int16_t;
-typedef unsigned short uint16_t;
-typedef __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#endif
-typedef SOCKET sock_t;
-typedef uint32_t in_addr_t;
-#ifndef UINT16_MAX
-#define UINT16_MAX 65535
-#endif
-#ifndef UINT32_MAX
-#define UINT32_MAX 4294967295
-#endif
-#ifndef pid_t
-#define pid_t HANDLE
-#endif
-#define INT64_FMT "I64d"
-#define INT64_X_FMT "I64x"
-#define SIZE_T_FMT "Iu"
-typedef struct _stati64 cs_stat_t;
-#ifndef S_ISDIR
-#define S_ISDIR(x) (((x) &_S_IFMT) == _S_IFDIR)
-#endif
-#ifndef S_ISREG
-#define S_ISREG(x) (((x) &_S_IFMT) == _S_IFREG)
-#endif
-#define DIRSEP '\\'
-#define CS_DEFINE_DIRENT
-
-#ifndef va_copy
-#ifdef __va_copy
-#define va_copy __va_copy
-#else
-#define va_copy(x, y) (x) = (y)
-#endif
-#endif
-
-#ifndef MG_MAX_HTTP_REQUEST_SIZE
-#define MG_MAX_HTTP_REQUEST_SIZE 8192
-#endif
-
-#ifndef MG_MAX_HTTP_SEND_MBUF
-#define MG_MAX_HTTP_SEND_MBUF 4096
-#endif
-
-#ifndef MG_MAX_HTTP_HEADERS
-#define MG_MAX_HTTP_HEADERS 40
-#endif
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#ifndef MG_ENABLE_BROADCAST
-#define MG_ENABLE_BROADCAST 1
-#endif
-
-#ifndef MG_ENABLE_DIRECTORY_LISTING
-#define MG_ENABLE_DIRECTORY_LISTING 1
-#endif
-
-#ifndef MG_ENABLE_FILESYSTEM
-#define MG_ENABLE_FILESYSTEM 1
-#endif
-
-#ifndef MG_ENABLE_HTTP_CGI
-#define MG_ENABLE_HTTP_CGI MG_ENABLE_FILESYSTEM
-#endif
-
-#ifndef MG_NET_IF
-#define MG_NET_IF MG_NET_IF_SOCKET
-#endif
-
-unsigned int sleep(unsigned int seconds);
-
-/* https://stackoverflow.com/questions/16647819/timegm-cross-platform */
-#define timegm _mkgmtime
-
-#define gmtime_r(a, b) \
-  do {                 \
-    *(b) = *gmtime(a); \
-  } while (0)
-
-#endif /* CS_PLATFORM == CS_P_WINDOWS */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_WINDOWS_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_unix.h"
-#endif
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_UNIX_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_UNIX_H_
-#if CS_PLATFORM == CS_P_UNIX
-
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600
-#endif
-
-/* <inttypes.h> wants this for C++ */
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-/* C++ wants that for INT64_MAX */
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
-/* Enable fseeko() and ftello() functions */
-#ifndef _LARGEFILE_SOURCE
-#define _LARGEFILE_SOURCE
-#endif
-
-/* Enable 64-bit file offsets */
-#ifndef _FILE_OFFSET_BITS
-#define _FILE_OFFSET_BITS 64
-#endif
-
-#include <arpa/inet.h>
-#include <assert.h>
-#include <ctype.h>
-#include <dirent.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <stdint.h>
-#include <limits.h>
-#include <math.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <pthread.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/param.h>
-#include <sys/socket.h>
-#include <sys/select.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#ifdef __APPLE__
-#include <machine/endian.h>
-#ifndef BYTE_ORDER
-#define LITTLE_ENDIAN __DARWIN_LITTLE_ENDIAN
-#define BIG_ENDIAN __DARWIN_BIG_ENDIAN
-#define PDP_ENDIAN __DARWIN_PDP_ENDIAN
-#define BYTE_ORDER __DARWIN_BYTE_ORDER
-#endif
-#endif
-
-/*
- * osx correctly avoids defining strtoll when compiling in strict ansi mode.
- * c++ 11 standard defines strtoll as well.
- * We require strtoll, and if your embedded pre-c99 compiler lacks one, please
- * implement a shim.
- */
-#if !(defined(__cplusplus) && __cplusplus >= 201103L) && \
-    !(defined(__DARWIN_C_LEVEL) && __DARWIN_C_LEVEL >= 200809L)
-long long strtoll(const char *, char **, int);
-#endif
-
-typedef int sock_t;
-#define INVALID_SOCKET (-1)
-#define SIZE_T_FMT "zu"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-
-#ifndef __cdecl
-#define __cdecl
-#endif
-
-#ifndef va_copy
-#ifdef __va_copy
-#define va_copy __va_copy
-#else
-#define va_copy(x, y) (x) = (y)
-#endif
-#endif
-
-#define closesocket(x) close(x)
-
-#ifndef MG_MAX_HTTP_REQUEST_SIZE
-#define MG_MAX_HTTP_REQUEST_SIZE 8192
-#endif
-
-#ifndef MG_MAX_HTTP_SEND_MBUF
-#define MG_MAX_HTTP_SEND_MBUF 4096
-#endif
-
-#ifndef MG_MAX_HTTP_HEADERS
-#define MG_MAX_HTTP_HEADERS 40
-#endif
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#ifndef MG_ENABLE_BROADCAST
-#define MG_ENABLE_BROADCAST 1
-#endif
-
-#ifndef MG_ENABLE_DIRECTORY_LISTING
-#define MG_ENABLE_DIRECTORY_LISTING 1
-#endif
-
-#ifndef MG_ENABLE_FILESYSTEM
-#define MG_ENABLE_FILESYSTEM 1
-#endif
-
-#ifndef MG_ENABLE_HTTP_CGI
-#define MG_ENABLE_HTTP_CGI MG_ENABLE_FILESYSTEM
-#endif
-
-#ifndef MG_NET_IF
-#define MG_NET_IF MG_NET_IF_SOCKET
-#endif
-
-#ifndef MG_HOSTS_FILE_NAME
-#define MG_HOSTS_FILE_NAME "/etc/hosts"
-#endif
-
-#ifndef MG_RESOLV_CONF_FILE_NAME
-#define MG_RESOLV_CONF_FILE_NAME "/etc/resolv.conf"
-#endif
-
-#endif /* CS_PLATFORM == CS_P_UNIX */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_UNIX_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_esp32.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_ESP32_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_ESP32_H_
-#if CS_PLATFORM == CS_P_ESP32
-
-#include <assert.h>
-#include <ctype.h>
-#include <dirent.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <machine/endian.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-#define __cdecl
-#define _FILE_OFFSET_BITS 32
-
-#define MG_LWIP 1
-
-#ifndef MG_NET_IF
-#define MG_NET_IF MG_NET_IF_SOCKET
-#endif
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#endif /* CS_PLATFORM == CS_P_ESP32 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_ESP32_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_esp8266.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_ESP8266_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_ESP8266_H_
-#if CS_PLATFORM == CS_P_ESP8266
-
-#include <assert.h>
-#include <ctype.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <machine/endian.h>
-#include <stdbool.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-#if !defined(MGOS_VFS_DEFINE_DIRENT)
-#define CS_DEFINE_DIRENT
-#endif
-
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-#define __cdecl
-#define _FILE_OFFSET_BITS 32
-
-#define MG_LWIP 1
-
-/* struct timeval is defined in sys/time.h. */
-#define LWIP_TIMEVAL_PRIVATE 0
-
-#ifndef MG_NET_IF
-#include <lwip/opt.h>
-#if LWIP_SOCKET /* RTOS SDK has LWIP sockets */
-#define MG_NET_IF MG_NET_IF_SOCKET
-#else
-#define MG_NET_IF MG_NET_IF_LWIP_LOW_LEVEL
-#endif
-#endif
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#define inet_ntop(af, src, dst, size)                                          \
-  (((af) == AF_INET) ? ipaddr_ntoa_r((const ip_addr_t *) (src), (dst), (size)) \
-                     : NULL)
-#define inet_pton(af, src, dst) \
-  (((af) == AF_INET) ? ipaddr_aton((src), (ip_addr_t *) (dst)) : 0)
-
-#endif /* CS_PLATFORM == CS_P_ESP8266 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_ESP8266_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_cc3100.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_CC3100_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_CC3100_H_
-#if CS_PLATFORM == CS_P_CC3100
-
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <inttypes.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-
-#define MG_NET_IF MG_NET_IF_SIMPLELINK
-#define MG_SSL_IF MG_SSL_IF_SIMPLELINK
-
-/*
- * CC3100 SDK and STM32 SDK include headers w/out path, just like
- * #include "simplelink.h". As result, we have to add all required directories
- * into Makefile IPATH and do the same thing (include w/out path)
- */
-
-#include <simplelink.h>
-#include <netapp.h>
-#undef timeval
-
-typedef int sock_t;
-#define INVALID_SOCKET (-1)
-
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-#define SIZE_T_FMT "u"
-
-#define SOMAXCONN 8
-
-const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
-char *inet_ntoa(struct in_addr in);
-int inet_pton(int af, const char *src, void *dst);
-
-#endif /* CS_PLATFORM == CS_P_CC3100 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_CC3100_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/simplelink/cs_simplelink.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_SIMPLELINK_CS_SIMPLELINK_H_
-#define CS_COMMON_PLATFORMS_SIMPLELINK_CS_SIMPLELINK_H_
-
-#if defined(MG_NET_IF) && MG_NET_IF == MG_NET_IF_SIMPLELINK
-
-/* If simplelink.h is already included, all bets are off. */
-#if !defined(__SIMPLELINK_H__)
-
-#include <stdbool.h>
-
-#ifndef __TI_COMPILER_VERSION__
-#undef __CONCAT
-#undef FD_CLR
-#undef FD_ISSET
-#undef FD_SET
-#undef FD_SETSIZE
-#undef FD_ZERO
-#undef fd_set
-#endif
-
-#if CS_PLATFORM == CS_P_CC3220
-#include <ti/drivers/net/wifi/porting/user.h>
-#include <ti/drivers/net/wifi/simplelink.h>
-#include <ti/drivers/net/wifi/sl_socket.h>
-#include <ti/drivers/net/wifi/netapp.h>
-#else
-/* We want to disable SL_INC_STD_BSD_API_NAMING, so we include user.h ourselves
- * and undef it. */
-#define PROVISIONING_API_H_
-#include <simplelink/user.h>
-#undef PROVISIONING_API_H_
-#undef SL_INC_STD_BSD_API_NAMING
-
-#include <simplelink/include/simplelink.h>
-#include <simplelink/include/netapp.h>
-#endif /* CS_PLATFORM == CS_P_CC3220 */
-
-/* Now define only the subset of the BSD API that we use.
- * Notably, close(), read() and write() are not defined. */
-#define AF_INET SL_AF_INET
-
-#define socklen_t SlSocklen_t
-#define sockaddr SlSockAddr_t
-#define sockaddr_in SlSockAddrIn_t
-#define in_addr SlInAddr_t
-
-#define SOCK_STREAM SL_SOCK_STREAM
-#define SOCK_DGRAM SL_SOCK_DGRAM
-
-#define htonl sl_Htonl
-#define ntohl sl_Ntohl
-#define htons sl_Htons
-#define ntohs sl_Ntohs
-
-#ifndef EACCES
-#define EACCES SL_EACCES
-#endif
-#ifndef EAFNOSUPPORT
-#define EAFNOSUPPORT SL_EAFNOSUPPORT
-#endif
-#ifndef EAGAIN
-#define EAGAIN SL_EAGAIN
-#endif
-#ifndef EBADF
-#define EBADF SL_EBADF
-#endif
-#ifndef EINVAL
-#define EINVAL SL_EINVAL
-#endif
-#ifndef ENOMEM
-#define ENOMEM SL_ENOMEM
-#endif
-#ifndef EWOULDBLOCK
-#define EWOULDBLOCK SL_EWOULDBLOCK
-#endif
-
-#define SOMAXCONN 8
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
-char *inet_ntoa(struct in_addr in);
-int inet_pton(int af, const char *src, void *dst);
-
-struct mg_mgr;
-struct mg_connection;
-
-typedef void (*mg_init_cb)(struct mg_mgr *mgr);
-bool mg_start_task(int priority, int stack_size, mg_init_cb mg_init);
-
-void mg_run_in_task(void (*cb)(struct mg_mgr *mgr, void *arg), void *cb_arg);
-
-int sl_fs_init(void);
-
-void sl_restart_cb(struct mg_mgr *mgr);
-
-int sl_set_ssl_opts(int sock, struct mg_connection *nc);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* !defined(__SIMPLELINK_H__) */
-
-/* Compatibility with older versions of SimpleLink */
-#if SL_MAJOR_VERSION_NUM < 2
-
-#define SL_ERROR_BSD_EAGAIN SL_EAGAIN
-#define SL_ERROR_BSD_EALREADY SL_EALREADY
-#define SL_ERROR_BSD_ENOPROTOOPT SL_ENOPROTOOPT
-#define SL_ERROR_BSD_ESECDATEERROR SL_ESECDATEERROR
-#define SL_ERROR_BSD_ESECSNOVERIFY SL_ESECSNOVERIFY
-#define SL_ERROR_FS_FAILED_TO_ALLOCATE_MEM SL_FS_ERR_FAILED_TO_ALLOCATE_MEM
-#define SL_ERROR_FS_FILE_HAS_NOT_BEEN_CLOSE_CORRECTLY \
-  SL_FS_FILE_HAS_NOT_BEEN_CLOSE_CORRECTLY
-#define SL_ERROR_FS_FILE_NAME_EXIST SL_FS_FILE_NAME_EXIST
-#define SL_ERROR_FS_FILE_NOT_EXISTS SL_FS_ERR_FILE_NOT_EXISTS
-#define SL_ERROR_FS_NO_AVAILABLE_NV_INDEX SL_FS_ERR_NO_AVAILABLE_NV_INDEX
-#define SL_ERROR_FS_NOT_ENOUGH_STORAGE_SPACE SL_FS_ERR_NO_AVAILABLE_BLOCKS
-#define SL_ERROR_FS_NOT_SUPPORTED SL_FS_ERR_NOT_SUPPORTED
-#define SL_ERROR_FS_WRONG_FILE_NAME SL_FS_WRONG_FILE_NAME
-#define SL_ERROR_FS_INVALID_HANDLE SL_FS_ERR_INVALID_HANDLE
-#define SL_NETCFG_MAC_ADDRESS_GET SL_MAC_ADDRESS_GET
-#define SL_SOCKET_FD_ZERO SL_FD_ZERO
-#define SL_SOCKET_FD_SET SL_FD_SET
-#define SL_SOCKET_FD_ISSET SL_FD_ISSET
-#define SL_SO_SECURE_DOMAIN_NAME_VERIFICATION SO_SECURE_DOMAIN_NAME_VERIFICATION
-
-#define SL_FS_READ FS_MODE_OPEN_READ
-#define SL_FS_WRITE FS_MODE_OPEN_WRITE
-
-#define SL_FI_FILE_SIZE(fi) ((fi).FileLen)
-#define SL_FI_FILE_MAX_SIZE(fi) ((fi).AllocatedLen)
-
-#define SlDeviceVersion_t SlVersionFull
-#define sl_DeviceGet sl_DevGet
-#define SL_DEVICE_GENERAL SL_DEVICE_GENERAL_CONFIGURATION
-#define SL_LEN_TYPE _u8
-#define SL_OPT_TYPE _u8
-
-#else /* SL_MAJOR_VERSION_NUM >= 2 */
-
-#define FS_MODE_OPEN_CREATE(max_size, flag) \
-  (SL_FS_CREATE | SL_FS_CREATE_MAX_SIZE(max_size))
-#define SL_FI_FILE_SIZE(fi) ((fi).Len)
-#define SL_FI_FILE_MAX_SIZE(fi) ((fi).MaxSize)
-
-#define SL_LEN_TYPE _u16
-#define SL_OPT_TYPE _u16
-
-#endif /* SL_MAJOR_VERSION_NUM < 2 */
-
-int slfs_open(const unsigned char *fname, uint32_t flags, uint32_t *token);
-
-#endif /* MG_NET_IF == MG_NET_IF_SIMPLELINK */
-
-#endif /* CS_COMMON_PLATFORMS_SIMPLELINK_CS_SIMPLELINK_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_cc3200.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_CC3200_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_CC3200_H_
-#if CS_PLATFORM == CS_P_CC3200
-
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <inttypes.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-
-#ifndef __TI_COMPILER_VERSION__
-#include <fcntl.h>
-#include <sys/time.h>
-#endif
-
-#define MG_NET_IF MG_NET_IF_SIMPLELINK
-#define MG_SSL_IF MG_SSL_IF_SIMPLELINK
-
-/* Only SPIFFS supports directories, SLFS does not. */
-#if defined(CC3200_FS_SPIFFS) && !defined(MG_ENABLE_DIRECTORY_LISTING)
-#define MG_ENABLE_DIRECTORY_LISTING 1
-#endif
-
-/* Amalgamated: #include "common/platforms/simplelink/cs_simplelink.h" */
-
-typedef int sock_t;
-#define INVALID_SOCKET (-1)
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-#define __cdecl
-
-#define fileno(x) -1
-
-/* Some functions we implement for Mongoose. */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef __TI_COMPILER_VERSION__
-struct SlTimeval_t;
-#define timeval SlTimeval_t
-int gettimeofday(struct timeval *t, void *tz);
-int settimeofday(const struct timeval *tv, const void *tz);
-
-int asprintf(char **strp, const char *fmt, ...);
-
-#endif
-
-/* TI's libc does not have stat & friends, add them. */
-#ifdef __TI_COMPILER_VERSION__
-
-#include <file.h>
-
-typedef unsigned int mode_t;
-typedef size_t _off_t;
-typedef long ssize_t;
-
-struct stat {
-  int st_ino;
-  mode_t st_mode;
-  int st_nlink;
-  time_t st_mtime;
-  off_t st_size;
-};
-
-int _stat(const char *pathname, struct stat *st);
-int stat(const char *pathname, struct stat *st);
-
-#define __S_IFMT 0170000
-
-#define __S_IFDIR 0040000
-#define __S_IFCHR 0020000
-#define __S_IFREG 0100000
-
-#define __S_ISTYPE(mode, mask) (((mode) &__S_IFMT) == (mask))
-
-#define S_IFDIR __S_IFDIR
-#define S_IFCHR __S_IFCHR
-#define S_IFREG __S_IFREG
-#define S_ISDIR(mode) __S_ISTYPE((mode), __S_IFDIR)
-#define S_ISREG(mode) __S_ISTYPE((mode), __S_IFREG)
-
-/* 5.x series compilers don't have va_copy, 16.x do. */
-#if __TI_COMPILER_VERSION__ < 16000000
-#define va_copy(apc, ap) ((apc) = (ap))
-#endif
-
-#endif /* __TI_COMPILER_VERSION__ */
-
-#ifdef CC3200_FS_SLFS
-#define MG_FS_SLFS
-#endif
-
-#if (defined(CC3200_FS_SPIFFS) || defined(CC3200_FS_SLFS)) && \
-    !defined(MG_ENABLE_FILESYSTEM)
-#define MG_ENABLE_FILESYSTEM 1
-#define CS_DEFINE_DIRENT
-#endif
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_PLATFORM == CS_P_CC3200 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_CC3200_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_cc3220.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_CC3220_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_CC3220_H_
-#if CS_PLATFORM == CS_P_CC3220
-
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <inttypes.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-
-#ifndef __TI_COMPILER_VERSION__
-#include <fcntl.h>
-#include <sys/time.h>
-#endif
-
-#define MG_NET_IF MG_NET_IF_SIMPLELINK
-#ifndef MG_SSL_IF
-#define MG_SSL_IF MG_SSL_IF_SIMPLELINK
-#endif
-
-/* Only SPIFFS supports directories, SLFS does not. */
-#if defined(CC3220_FS_SPIFFS) && !defined(MG_ENABLE_DIRECTORY_LISTING)
-#define MG_ENABLE_DIRECTORY_LISTING 1
-#endif
-
-/* Amalgamated: #include "common/platforms/simplelink/cs_simplelink.h" */
-
-typedef int sock_t;
-#define INVALID_SOCKET (-1)
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-#define __cdecl
-
-#define fileno(x) -1
-
-/* Some functions we implement for Mongoose. */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef __TI_COMPILER_VERSION__
-struct SlTimeval_t;
-#define timeval SlTimeval_t
-int gettimeofday(struct timeval *t, void *tz);
-int settimeofday(const struct timeval *tv, const void *tz);
-
-int asprintf(char **strp, const char *fmt, ...);
-
-#endif
-
-/* TI's libc does not have stat & friends, add them. */
-#ifdef __TI_COMPILER_VERSION__
-
-#include <file.h>
-
-typedef unsigned int mode_t;
-typedef size_t _off_t;
-typedef long ssize_t;
-
-struct stat {
-  int st_ino;
-  mode_t st_mode;
-  int st_nlink;
-  time_t st_mtime;
-  off_t st_size;
-};
-
-int _stat(const char *pathname, struct stat *st);
-int stat(const char *pathname, struct stat *st);
-
-#define __S_IFMT 0170000
-
-#define __S_IFDIR 0040000
-#define __S_IFCHR 0020000
-#define __S_IFREG 0100000
-
-#define __S_ISTYPE(mode, mask) (((mode) &__S_IFMT) == (mask))
-
-#define S_IFDIR __S_IFDIR
-#define S_IFCHR __S_IFCHR
-#define S_IFREG __S_IFREG
-#define S_ISDIR(mode) __S_ISTYPE((mode), __S_IFDIR)
-#define S_ISREG(mode) __S_ISTYPE((mode), __S_IFREG)
-
-#endif /* __TI_COMPILER_VERSION__ */
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_PLATFORM == CS_P_CC3220 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_CC3200_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_mbed.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_MBED_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_MBED_H_
-#if CS_PLATFORM == CS_P_MBED
-
-/*
- * mbed.h contains C++ code (e.g. templates), thus, it should be processed
- * only if included directly to startup file (ex: main.cpp)
- */
-#ifdef __cplusplus
-/* Amalgamated: #include "mbed.h" */
-#endif /* __cplusplus */
-
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <inttypes.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <fcntl.h>
-#include <stdio.h>
-
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-/*
- * mbed can be compiled with the ARM compiler which
- * just doesn't come with a gettimeofday shim
- * because it's a BSD API and ARM targets embedded
- * non-unix platforms.
- */
-#if defined(__ARMCC_VERSION) || defined(__ICCARM__)
-#define _TIMEVAL_DEFINED
-#define gettimeofday _gettimeofday
-
-/* copied from GCC on ARM; for some reason useconds are signed */
-typedef long suseconds_t; /* microseconds (signed) */
-struct timeval {
-  time_t tv_sec;       /* seconds */
-  suseconds_t tv_usec; /* and microseconds */
-};
-
-#endif
-
-#if MG_NET_IF == MG_NET_IF_SIMPLELINK
-
-#define MG_SIMPLELINK_NO_OSI 1
-
-#include <simplelink.h>
-
-typedef int sock_t;
-#define INVALID_SOCKET (-1)
-
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT PRId64
-#define INT64_X_FMT PRIx64
-#define SIZE_T_FMT "u"
-
-#define SOMAXCONN 8
-
-const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
-char *inet_ntoa(struct in_addr in);
-int inet_pton(int af, const char *src, void *dst);
-int inet_aton(const char *cp, struct in_addr *inp);
-in_addr_t inet_addr(const char *cp);
-
-#endif /* MG_NET_IF == MG_NET_IF_SIMPLELINK */
-
-#endif /* CS_PLATFORM == CS_P_MBED */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_MBED_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_nrf51.h"
-#endif
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_NRF51_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_NRF51_H_
-#if CS_PLATFORM == CS_P_NRF51
-
-#include <assert.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-
-#define to64(x) strtoll(x, NULL, 10)
-
-#define MG_NET_IF MG_NET_IF_LWIP_LOW_LEVEL
-#define MG_LWIP 1
-#define MG_ENABLE_IPV6 1
-
-/*
- * For ARM C Compiler, make lwip to export `struct timeval`; for other
- * compilers, suppress it.
- */
-#if !defined(__ARMCC_VERSION)
-#define LWIP_TIMEVAL_PRIVATE 0
-#else
-struct timeval;
-int gettimeofday(struct timeval *tp, void *tzp);
-#endif
-
-#define INT64_FMT PRId64
-#define SIZE_T_FMT "u"
-
-/*
- * ARM C Compiler doesn't have strdup, so we provide it
- */
-#define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
-
-#endif /* CS_PLATFORM == CS_P_NRF51 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_NRF51_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_nrf52.h"
-#endif
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_NRF52_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_NRF52_H_
-#if CS_PLATFORM == CS_P_NRF52
-
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <inttypes.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-
-#define to64(x) strtoll(x, NULL, 10)
-
-#define MG_NET_IF MG_NET_IF_LWIP_LOW_LEVEL
-#define MG_LWIP 1
-#define MG_ENABLE_IPV6 1
-
-#if !defined(ENOSPC)
-#define ENOSPC 28 /* No space left on device */
-#endif
-
-/*
- * For ARM C Compiler, make lwip to export `struct timeval`; for other
- * compilers, suppress it.
- */
-#if !defined(__ARMCC_VERSION)
-#define LWIP_TIMEVAL_PRIVATE 0
-#endif
-
-#define INT64_FMT PRId64
-#define SIZE_T_FMT "u"
-
-/*
- * ARM C Compiler doesn't have strdup, so we provide it
- */
-#define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
-
-#endif /* CS_PLATFORM == CS_P_NRF52 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_NRF52_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_wince.h"
-#endif
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_WINCE_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_WINCE_H_
-
-#if CS_PLATFORM == CS_P_WINCE
-
-/*
- * MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
- * MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
- * MSVC++ 11.0 _MSC_VER == 1700 (Visual Studio 2012)
- * MSVC++ 10.0 _MSC_VER == 1600 (Visual Studio 2010)
- * MSVC++ 9.0  _MSC_VER == 1500 (Visual Studio 2008)
- * MSVC++ 8.0  _MSC_VER == 1400 (Visual Studio 2005)
- * MSVC++ 7.1  _MSC_VER == 1310 (Visual Studio 2003)
- * MSVC++ 7.0  _MSC_VER == 1300
- * MSVC++ 6.0  _MSC_VER == 1200
- * MSVC++ 5.0  _MSC_VER == 1100
- */
-#pragma warning(disable : 4127) /* FD_SET() emits warning, disable it */
-#pragma warning(disable : 4204) /* missing c99 support */
-
-#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS 1
-#endif
-
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
-#include <assert.h>
-#include <limits.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-
-#pragma comment(lib, "ws2.lib") /* Linking with WinCE winsock library */
-
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <windows.h>
-
-#define strdup _strdup
-
-#ifndef EINPROGRESS
-#define EINPROGRESS WSAEINPROGRESS
-#endif
-
-#ifndef EWOULDBLOCK
-#define EWOULDBLOCK WSAEWOULDBLOCK
-#endif
-
-#ifndef EAGAIN
-#define EAGAIN EWOULDBLOCK
-#endif
-
-#ifndef __func__
-#define STRX(x) #x
-#define STR(x) STRX(x)
-#define __func__ __FILE__ ":" STR(__LINE__)
-#endif
-
-#define snprintf _snprintf
-#define fileno _fileno
-#define vsnprintf _vsnprintf
-#define sleep(x) Sleep((x) *1000)
-#define to64(x) _atoi64(x)
-#define rmdir _rmdir
-
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-#define fseeko(x, y, z) _fseeki64((x), (y), (z))
-#else
-#define fseeko(x, y, z) fseek((x), (y), (z))
-#endif
-
-typedef int socklen_t;
-
-#if _MSC_VER >= 1700
-#include <stdint.h>
-#else
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef int int32_t;
-typedef unsigned int uint32_t;
-typedef short int16_t;
-typedef unsigned short uint16_t;
-typedef __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#endif
-
-typedef SOCKET sock_t;
-typedef uint32_t in_addr_t;
-
-#ifndef UINT16_MAX
-#define UINT16_MAX 65535
-#endif
-
-#ifndef UINT32_MAX
-#define UINT32_MAX 4294967295
-#endif
-
-#ifndef pid_t
-#define pid_t HANDLE
-#endif
-
-#define INT64_FMT "I64d"
-#define INT64_X_FMT "I64x"
-/* TODO(alashkin): check if this is correct */
-#define SIZE_T_FMT "u"
-
-#define DIRSEP '\\'
-#define CS_DEFINE_DIRENT
-
-#ifndef va_copy
-#ifdef __va_copy
-#define va_copy __va_copy
-#else
-#define va_copy(x, y) (x) = (y)
-#endif
-#endif
-
-#ifndef MG_MAX_HTTP_REQUEST_SIZE
-#define MG_MAX_HTTP_REQUEST_SIZE 8192
-#endif
-
-#ifndef MG_MAX_HTTP_SEND_MBUF
-#define MG_MAX_HTTP_SEND_MBUF 4096
-#endif
-
-#ifndef MG_MAX_HTTP_HEADERS
-#define MG_MAX_HTTP_HEADERS 40
-#endif
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#define abort() DebugBreak();
-
-#ifndef BUFSIZ
-#define BUFSIZ 4096
-#endif
-/*
- * Explicitly disabling MG_ENABLE_THREADS for WinCE
- * because they are enabled for _WIN32 by default
- */
-#ifndef MG_ENABLE_THREADS
-#define MG_ENABLE_THREADS 0
-#endif
-
-#ifndef MG_ENABLE_FILESYSTEM
-#define MG_ENABLE_FILESYSTEM 1
-#endif
-
-#ifndef MG_NET_IF
-#define MG_NET_IF MG_NET_IF_SOCKET
-#endif
-
-typedef struct _stati64 {
-  uint32_t st_mtime;
-  uint32_t st_size;
-  uint32_t st_mode;
-} cs_stat_t;
-
-/*
- * WinCE 6.0 has a lot of useful definitions in ATL (not windows.h) headers
- * use #ifdefs to avoid conflicts
- */
-
-#ifndef ENOENT
-#define ENOENT ERROR_PATH_NOT_FOUND
-#endif
-
-#ifndef EACCES
-#define EACCES ERROR_ACCESS_DENIED
-#endif
-
-#ifndef ENOMEM
-#define ENOMEM ERROR_NOT_ENOUGH_MEMORY
-#endif
-
-#ifndef _UINTPTR_T_DEFINED
-typedef unsigned int *uintptr_t;
-#endif
-
-#define _S_IFREG 2
-#define _S_IFDIR 4
-
-#ifndef S_ISDIR
-#define S_ISDIR(x) (((x) &_S_IFDIR) != 0)
-#endif
-
-#ifndef S_ISREG
-#define S_ISREG(x) (((x) &_S_IFREG) != 0)
-#endif
-
-int open(const char *filename, int oflag, int pmode);
-int _wstati64(const wchar_t *path, cs_stat_t *st);
-const char *strerror();
-
-#endif /* CS_PLATFORM == CS_P_WINCE */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_WINCE_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_nxp_lpc.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_NXP_LPC_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_NXP_LPC_H_
-
-#if CS_PLATFORM == CS_P_NXP_LPC
-
-#include <ctype.h>
-#include <stdint.h>
-#include <string.h>
-
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define INT64_FMT "lld"
-#define INT64_X_FMT "llx"
-#define __cdecl
-
-#define MG_LWIP 1
-
-#define MG_NET_IF MG_NET_IF_LWIP_LOW_LEVEL
-
-/*
- * LPCXpress comes with 3 C library implementations: Newlib, NewlibNano and
- *Redlib.
- * See https://community.nxp.com/message/630860 for more details.
- *
- * Redlib is the default and lacks certain things, so we provide them.
- */
-#ifdef __REDLIB_INTERFACE_VERSION__
-
-/* Let LWIP define timeval for us. */
-#define LWIP_TIMEVAL_PRIVATE 1
-
-#define va_copy(d, s) __builtin_va_copy(d, s)
-
-#define CS_ENABLE_TO64 1
-#define to64(x) cs_to64(x)
-
-#define CS_ENABLE_STRDUP 1
-
-#else
-
-#include <sys/time.h>
-#define LWIP_TIMEVAL_PRIVATE 0
-#define to64(x) strtoll(x, NULL, 10)
-
-#endif
-
-#endif /* CS_PLATFORM == CS_P_NXP_LPC */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_NXP_LPC_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_nxp_kinetis.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_NXP_KINETIS_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_NXP_KINETIS_H_
-
-#if CS_PLATFORM == CS_P_NXP_KINETIS
-
-#include <ctype.h>
-#include <inttypes.h>
-#include <string.h>
-#include <sys/time.h>
-
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT "lld"
-#define INT64_X_FMT "llx"
-#define __cdecl
-
-#define MG_LWIP 1
-
-#define MG_NET_IF MG_NET_IF_LWIP_LOW_LEVEL
-
-/* struct timeval is defined in sys/time.h. */
-#define LWIP_TIMEVAL_PRIVATE 0
-
-#endif /* CS_PLATFORM == CS_P_NXP_KINETIS */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_NXP_KINETIS_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_pic32.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_PIC32_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_PIC32_H_
-
-#if CS_PLATFORM == CS_P_PIC32
-
-#define MG_NET_IF MG_NET_IF_PIC32
-
-#include <stdint.h>
-#include <time.h>
-#include <ctype.h>
-#include <stdlib.h>
-
-#include <system_config.h>
-#include <system_definitions.h>
-
-#include <sys/types.h>
-
-typedef TCP_SOCKET sock_t;
-#define to64(x) strtoll(x, NULL, 10)
-
-#define SIZE_T_FMT "lu"
-#define INT64_FMT "lld"
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-char *inet_ntoa(struct in_addr in);
-
-#endif /* CS_PLATFORM == CS_P_PIC32 */
-
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_PIC32_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_rs14100.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_RS14100_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_RS14100_H_
-#if CS_PLATFORM == CS_P_RS14100
-
-#include <ctype.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#ifdef MGOS_HAVE_VFS_COMMON
-#include <mgos_vfs.h>
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT "lld"
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#ifndef MG_ENABLE_FILESYSTEM
-#define MG_ENABLE_FILESYSTEM 1
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_PLATFORM == CS_P_RS14100 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_RS14100_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/platforms/platform_stm32.h"
-#endif
-
-#ifndef CS_COMMON_PLATFORMS_PLATFORM_STM32_H_
-#define CS_COMMON_PLATFORMS_PLATFORM_STM32_H_
-#if CS_PLATFORM == CS_P_STM32
-
-#include <ctype.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <dirent.h>
-
-#include <stm32_sdk_hal.h>
-
-#define to64(x) strtoll(x, NULL, 10)
-#define INT64_FMT "lld"
-#define SIZE_T_FMT "u"
-typedef struct stat cs_stat_t;
-#define DIRSEP '/'
-
-#ifndef CS_ENABLE_STDIO
-#define CS_ENABLE_STDIO 1
-#endif
-
-#ifndef MG_ENABLE_FILESYSTEM
-#define MG_ENABLE_FILESYSTEM 1
-#endif
-
-#endif /* CS_PLATFORM == CS_P_STM32 */
-#endif /* CS_COMMON_PLATFORMS_PLATFORM_STM32_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_dbg.h"
-#endif
-
-#ifndef CS_COMMON_CS_DBG_H_
-#define CS_COMMON_CS_DBG_H_
-
-/* Amalgamated: #include "common/platform.h" */
-
-#if CS_ENABLE_STDIO
-#include <stdio.h>
-#endif
-
-#ifndef CS_ENABLE_DEBUG
-#define CS_ENABLE_DEBUG 0
-#endif
-
-#ifndef CS_LOG_PREFIX_LEN
-#define CS_LOG_PREFIX_LEN 24
-#endif
-
-#ifndef CS_LOG_ENABLE_TS_DIFF
-#define CS_LOG_ENABLE_TS_DIFF 0
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-/*
- * Log level; `LL_INFO` is the default. Use `cs_log_set_level()` to change it.
- */
-enum cs_log_level {
-  LL_NONE = -1,
-  LL_ERROR = 0,
-  LL_WARN = 1,
-  LL_INFO = 2,
-  LL_DEBUG = 3,
-  LL_VERBOSE_DEBUG = 4,
-
-  _LL_MIN = -2,
-  _LL_MAX = 5,
-};
-
-/*
- * Set max log level to print; messages with the level above the given one will
- * not be printed.
- */
-void cs_log_set_level(enum cs_log_level level);
-
-/*
- * A comma-separated set of prefix=level.
- * prefix is matched against the log prefix exactly as printed, including line
- * number, but partial match is ok. Check stops on first matching entry.
- * If nothing matches, default level is used.
- *
- * Examples:
- *   main.c:=4 - everything from main C at verbose debug level.
- *   mongoose.c=1,mjs.c=1,=4 - everything at verbose debug except mg_* and mjs_*
- *
- */
-void cs_log_set_file_level(const char *file_level);
-
-/*
- * Helper function which prints message prefix with the given `level`.
- * If message should be printed (according to the current log level
- * and filter), prints the prefix and returns 1, otherwise returns 0.
- *
- * Clients should typically just use `LOG()` macro.
- */
-int cs_log_print_prefix(enum cs_log_level level, const char *fname, int line);
-
-extern enum cs_log_level cs_log_level;
-
-#if CS_ENABLE_STDIO
-
-/*
- * Set file to write logs into. If `NULL`, logs go to `stderr`.
- */
-void cs_log_set_file(FILE *file);
-
-/*
- * Prints log to the current log file, appends "\n" in the end and flushes the
- * stream.
- */
-void cs_log_printf(const char *fmt, ...) PRINTF_LIKE(1, 2);
-
-#if CS_ENABLE_STDIO
-
-/*
- * Format and print message `x` with the given level `l`. Example:
- *
- * ```c
- * LOG(LL_INFO, ("my info message: %d", 123));
- * LOG(LL_DEBUG, ("my debug message: %d", 123));
- * ```
- */
-#define LOG(l, x)                                     \
-  do {                                                \
-    if (cs_log_print_prefix(l, __FILE__, __LINE__)) { \
-      cs_log_printf x;                                \
-    }                                                 \
-  } while (0)
-
-#else
-
-#define LOG(l, x) ((void) l)
-
-#endif
-
-#ifndef CS_NDEBUG
-
-/*
- * Shortcut for `LOG(LL_VERBOSE_DEBUG, (...))`
- */
-#define DBG(x) LOG(LL_VERBOSE_DEBUG, x)
-
-#else /* NDEBUG */
-
-#define DBG(x)
-
-#endif
-
-#else /* CS_ENABLE_STDIO */
-
-#define LOG(l, x)
-#define DBG(x)
-
-#endif
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
-
-#endif /* CS_COMMON_CS_DBG_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_time.h"
-#endif
-
-#ifndef CS_COMMON_CS_TIME_H_
-#define CS_COMMON_CS_TIME_H_
-
-#include <time.h>
-
-/* Amalgamated: #include "common/platform.h" */
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-/* Sub-second granularity time(). */
-double cs_time(void);
-
-/*
- * Similar to (non-standard) timegm, converts broken-down time into the number
- * of seconds since Unix Epoch.
- */
-double cs_timegm(const struct tm *tm);
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
-
-#endif /* CS_COMMON_CS_TIME_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/mg_str.h"
-#endif
-
-#ifndef CS_COMMON_MG_STR_H_
-#define CS_COMMON_MG_STR_H_
-
-#include <stddef.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* Describes chunk of memory */
-struct mg_str {
-  const char *p; /* Memory chunk pointer */
-  size_t len;    /* Memory chunk length */
-};
-
-/*
- * Helper function for creating mg_str struct from plain C string.
- * `NULL` is allowed and becomes `{NULL, 0}`.
- */
-struct mg_str mg_mk_str(const char *s);
-
-/*
- * Like `mg_mk_str`, but takes string length explicitly.
- */
-struct mg_str mg_mk_str_n(const char *s, size_t len);
-
-/* Macro for initializing mg_str. */
-#define MG_MK_STR(str_literal) \
-  { str_literal, sizeof(str_literal) - 1 }
-#define MG_MK_STR_N(str_literal, len) \
-  { str_literal, len }
-#define MG_NULL_STR \
-  { NULL, 0 }
-
-/*
- * Cross-platform version of `strcmp()` where where first string is
- * specified by `struct mg_str`.
- */
-int mg_vcmp(const struct mg_str *str2, const char *str1);
-
-/*
- * Cross-platform version of `strncasecmp()` where first string is
- * specified by `struct mg_str`.
- */
-int mg_vcasecmp(const struct mg_str *str2, const char *str1);
-
-/* Creates a copy of s (heap-allocated). */
-struct mg_str mg_strdup(const struct mg_str s);
-
-/*
- * Creates a copy of s (heap-allocated).
- * Resulting string is NUL-terminated (but NUL is not included in len).
- */
-struct mg_str mg_strdup_nul(const struct mg_str s);
-
-/*
- * Locates character in a string.
- */
-const char *mg_strchr(const struct mg_str s, int c);
-
-/*
- * Compare two `mg_str`s; return value is the same as `strcmp`.
- */
-int mg_strcmp(const struct mg_str str1, const struct mg_str str2);
-
-/*
- * Like `mg_strcmp`, but compares at most `n` characters.
- */
-int mg_strncmp(const struct mg_str str1, const struct mg_str str2, size_t n);
-
-/*
- * Compare two `mg_str`s ignoreing case; return value is the same as `strcmp`.
- */
-int mg_strcasecmp(const struct mg_str str1, const struct mg_str str2);
-
-/*
- * Free the string (assuming it was heap allocated).
- */
-void mg_strfree(struct mg_str *s);
-
-/*
- * Finds the first occurrence of a substring `needle` in the `haystack`.
- */
-const char *mg_strstr(const struct mg_str haystack, const struct mg_str needle);
-
-/* Strip whitespace at the start and the end of s */
-struct mg_str mg_strstrip(struct mg_str s);
-
-/* Returns 1 if s starts with the given prefix. */
-int mg_str_starts_with(struct mg_str s, struct mg_str prefix);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_COMMON_MG_STR_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/str_util.h"
-#endif
-
-#ifndef CS_COMMON_STR_UTIL_H_
-#define CS_COMMON_STR_UTIL_H_
-
-#include <stdarg.h>
-#include <stdlib.h>
-
-/* Amalgamated: #include "common/mg_str.h" */
-/* Amalgamated: #include "common/platform.h" */
-
-#ifndef CS_ENABLE_STRDUP
-#define CS_ENABLE_STRDUP 0
-#endif
-
-#ifndef CS_ENABLE_TO64
-#define CS_ENABLE_TO64 0
-#endif
-
-/*
- * Expands to a string representation of its argument: e.g.
- * `CS_STRINGIFY_LIT(5) expands to "5"`
- */
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-#define CS_STRINGIFY_LIT(...) #__VA_ARGS__
-#else
-#define CS_STRINGIFY_LIT(x) #x
-#endif
-
-/*
- * Expands to a string representation of its argument, which is allowed
- * to be a macro: e.g.
- *
- * #define FOO 123
- * CS_STRINGIFY_MACRO(FOO)
- *
- * expands to 123.
- */
-#define CS_STRINGIFY_MACRO(x) CS_STRINGIFY_LIT(x)
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/*
- * Equivalent of standard `strnlen()`.
- */
-size_t c_strnlen(const char *s, size_t maxlen);
-
-/*
- * Equivalent of standard `snprintf()`.
- */
-int c_snprintf(char *buf, size_t buf_size, const char *format, ...)
-    PRINTF_LIKE(3, 4);
-
-/*
- * Equivalent of standard `vsnprintf()`.
- */
-int c_vsnprintf(char *buf, size_t buf_size, const char *format, va_list ap);
-
-/*
- * Find the first occurrence of find in s, where the search is limited to the
- * first slen characters of s.
- */
-const char *c_strnstr(const char *s, const char *find, size_t slen);
-
-/*
- * Stringify binary data. Output buffer size must be 2 * size_of_input + 1
- * because each byte of input takes 2 bytes in string representation
- * plus 1 byte for the terminating \0 character.
- */
-void cs_to_hex(char *to, const unsigned char *p, size_t len);
-
-/*
- * Convert stringified binary data back to binary.
- * Does the reverse of `cs_to_hex()`.
- */
-void cs_from_hex(char *to, const char *p, size_t len);
-
-#if CS_ENABLE_STRDUP
-/*
- * Equivalent of standard `strdup()`, defined if only `CS_ENABLE_STRDUP` is 1.
- */
-char *strdup(const char *src);
-#endif
-
-#if CS_ENABLE_TO64
-#include <stdint.h>
-/*
- * Simple string -> int64 conversion routine.
- */
-int64_t cs_to64(const char *s);
-#endif
-
-/*
- * Cross-platform version of `strncasecmp()`.
- */
-int mg_ncasecmp(const char *s1, const char *s2, size_t len);
-
-/*
- * Cross-platform version of `strcasecmp()`.
- */
-int mg_casecmp(const char *s1, const char *s2);
-
-/*
- * Prints message to the buffer. If the buffer is large enough to hold the
- * message, it returns buffer. If buffer is to small, it allocates a large
- * enough buffer on heap and returns allocated buffer.
- * This is a supposed use case:
- *
- * ```c
- *    char buf[5], *p = buf;
- *    mg_avprintf(&p, sizeof(buf), "%s", "hi there");
- *    use_p_somehow(p);
- *    if (p != buf) {
- *      free(p);
- *    }
- * ```
- *
- * The purpose of this is to avoid malloc-ing if generated strings are small.
- */
-int mg_asprintf(char **buf, size_t size, const char *fmt, ...)
-    PRINTF_LIKE(3, 4);
-
-/* Same as mg_asprintf, but takes varargs list. */
-int mg_avprintf(char **buf, size_t size, const char *fmt, va_list ap);
-
-/*
- * A helper function for traversing a comma separated list of values.
- * It returns a list pointer shifted to the next value or NULL if the end
- * of the list found.
- * The value is stored in a val vector. If the value has a form "x=y", then
- * eq_val vector is initialised to point to the "y" part, and val vector length
- * is adjusted to point only to "x".
- * If the list is just a comma separated list of entries, like "aa,bb,cc" then
- * `eq_val` will contain zero-length string.
- *
- * The purpose of this function is to parse comma separated string without
- * any copying/memory allocation.
- */
-const char *mg_next_comma_list_entry(const char *list, struct mg_str *val,
-                                     struct mg_str *eq_val);
-
-/*
- * Like `mg_next_comma_list_entry()`, but takes `list` as `struct mg_str`.
- * NB: Test return value's .p, not .len. On last itreation that yields result
- * .len will be 0 but .p will not. When finished, .p will be NULL.
- */
-struct mg_str mg_next_comma_list_entry_n(struct mg_str list, struct mg_str *val,
-                                         struct mg_str *eq_val);
-
-/*
- * Matches 0-terminated string (mg_match_prefix) or string with given length
- * mg_match_prefix_n against a glob pattern. Glob syntax:
- * ```
- * - * matches zero or more characters until a slash character /
- * - ** matches zero or more characters
- * - ? Matches exactly one character which is not a slash /
- * - | or ,  divides alternative patterns
- * - any other character matches itself
- * ```
- * Match is case-insensitive. Return number of bytes matched.
- * Examples:
- * ```
- * mg_match_prefix("a*f", len, "abcdefgh") == 6
- * mg_match_prefix("a*f", len, "abcdexgh") == 0
- * mg_match_prefix("a*f|de*,xy", len, "defgh") == 5
- * mg_match_prefix("?*", len, "abc") == 3
- * mg_match_prefix("?*", len, "") == 0
- * ```
- */
-size_t mg_match_prefix(const char *pattern, int pattern_len, const char *str);
-
-/*
- * Like `mg_match_prefix()`, but takes `pattern` and `str` as `struct mg_str`.
- */
-size_t mg_match_prefix_n(const struct mg_str pattern, const struct mg_str str);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_COMMON_STR_UTIL_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_file.h"
-#endif
-
-#ifndef CS_COMMON_CS_FILE_H_
-#define CS_COMMON_CS_FILE_H_
-
-/* Amalgamated: #include "common/platform.h" */
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-/*
- * Read whole file `path` in memory. It is responsibility of the caller
- * to `free()` allocated memory. File content is guaranteed to be
- * '\0'-terminated. File size is returned in `size` variable, which does not
- * count terminating `\0`.
- * Return: allocated memory, or NULL on error.
- */
-char *cs_read_file(const char *path, size_t *size);
-
-#ifdef CS_MMAP
-/*
- * Only on platforms which support mmapping: mmap file `path` to the returned
- * address. File size is written to `*size`.
- */
-char *cs_mmap_file(const char *path, size_t *size);
-#endif
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
-
-#endif /* CS_COMMON_CS_FILE_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/mbuf.h"
-#endif
-
-/*
- * Mbufs are mutable/growing memory buffers, like C++ strings.
- * Mbuf can append data to the end of a buffer or insert data into arbitrary
- * position in the middle of a buffer. The buffer grows automatically when
- * needed.
- */
-
-#ifndef CS_COMMON_MBUF_H_
-#define CS_COMMON_MBUF_H_
-
-#include <stdlib.h>
-/* Amalgamated: #include "common/platform.h" */
-
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
-#ifndef MBUF_SIZE_MULTIPLIER
-#define MBUF_SIZE_MULTIPLIER 1.5
-#endif
-
-#ifndef MBUF_SIZE_MAX_HEADROOM
-#ifdef BUFSIZ
-#define MBUF_SIZE_MAX_HEADROOM BUFSIZ
-#else
-#define MBUF_SIZE_MAX_HEADROOM 1024
-#endif
-#endif
-
-/* Memory buffer descriptor */
-struct mbuf {
-  char *buf;   /* Buffer pointer */
-  size_t len;  /* Data length. Data is located between offset 0 and len. */
-  size_t size; /* Buffer size allocated by realloc(1). Must be >= len */
-};
-
-/*
- * Initialises an Mbuf.
- * `initial_capacity` specifies the initial capacity of the mbuf.
- */
-void mbuf_init(struct mbuf *, size_t initial_capacity);
-
-/* Frees the space allocated for the mbuffer and resets the mbuf structure. */
-void mbuf_free(struct mbuf *);
-
-/*
- * Appends data to the Mbuf.
- *
- * Returns the number of bytes appended or 0 if out of memory.
- */
-size_t mbuf_append(struct mbuf *, const void *data, size_t data_size);
-
-/*
- * Appends data to the Mbuf and frees it (data must be heap-allocated).
- *
- * Returns the number of bytes appended or 0 if out of memory.
- * data is freed irrespective of return value.
- */
-size_t mbuf_append_and_free(struct mbuf *, void *data, size_t data_size);
-
-/*
- * Inserts data at a specified offset in the Mbuf.
- *
- * Existing data will be shifted forwards and the buffer will
- * be grown if necessary.
- * Returns the number of bytes inserted.
- */
-size_t mbuf_insert(struct mbuf *, size_t, const void *, size_t);
-
-/* Removes `data_size` bytes from the beginning of the buffer. */
-void mbuf_remove(struct mbuf *, size_t data_size);
-
-/*
- * Resizes an Mbuf.
- *
- * If `new_size` is smaller than buffer's `len`, the
- * resize is not performed.
- */
-void mbuf_resize(struct mbuf *, size_t new_size);
-
-/* Moves the state from one mbuf to the other. */
-void mbuf_move(struct mbuf *from, struct mbuf *to);
-
-/* Removes all the data from mbuf (if any). */
-void mbuf_clear(struct mbuf *);
-
-/* Shrinks an Mbuf by resizing its `size` to `len`. */
-void mbuf_trim(struct mbuf *);
-
-#if defined(__cplusplus)
-}
-#endif /* __cplusplus */
-
-#endif /* CS_COMMON_MBUF_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/mg_mem.h"
-#endif
-
-#ifndef CS_COMMON_MG_MEM_H_
-#define CS_COMMON_MG_MEM_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifndef MG_MALLOC
-#define MG_MALLOC malloc
-#endif
-
-#ifndef MG_CALLOC
-#define MG_CALLOC calloc
-#endif
-
-#ifndef MG_REALLOC
-#define MG_REALLOC realloc
-#endif
-
-#ifndef MG_FREE
-#define MG_FREE free
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_COMMON_MG_MEM_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/frozen/frozen.h"
-#endif
-
-#ifndef CS_FROZEN_FROZEN_H_
-#define CS_FROZEN_FROZEN_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-#include <stdarg.h>
-#include <stddef.h>
-#include <stdio.h>
-
-#if defined(_WIN32) && _MSC_VER < 1700
-typedef int bool;
-enum { false = 0, true = 1 };
-#else
-#include <stdbool.h>
-#endif
-
-/* JSON token type */
-enum json_token_type {
-  JSON_TYPE_INVALID = 0, /* memsetting to 0 should create INVALID value */
-  JSON_TYPE_STRING,
-  JSON_TYPE_NUMBER,
-  JSON_TYPE_TRUE,
-  JSON_TYPE_FALSE,
-  JSON_TYPE_NULL,
-  JSON_TYPE_OBJECT_START,
-  JSON_TYPE_OBJECT_END,
-  JSON_TYPE_ARRAY_START,
-  JSON_TYPE_ARRAY_END,
-
-  JSON_TYPES_CNT
-};
-
-/*
- * Structure containing token type and value. Used in `json_walk()` and
- * `json_scanf()` with the format specifier `%T`.
- */
-struct json_token {
-  const char *ptr;           /* Points to the beginning of the value */
-  int len;                   /* Value length */
-  enum json_token_type type; /* Type of the token, possible values are above */
-};
-
-#define JSON_INVALID_TOKEN \
-  { 0, 0, JSON_TYPE_INVALID }
-
-/* Error codes */
-#define JSON_STRING_INVALID -1
-#define JSON_STRING_INCOMPLETE -2
-
-/*
- * Callback-based SAX-like API.
- *
- * Property name and length is given only if it's available: i.e. if current
- * event is an object's property. In other cases, `name` is `NULL`. For
- * example, name is never given:
- *   - For the first value in the JSON string;
- *   - For events JSON_TYPE_OBJECT_END and JSON_TYPE_ARRAY_END
- *
- * E.g. for the input `{ "foo": 123, "bar": [ 1, 2, { "baz": true } ] }`,
- * the sequence of callback invocations will be as follows:
- *
- * - type: JSON_TYPE_OBJECT_START, name: NULL, path: "", value: NULL
- * - type: JSON_TYPE_NUMBER, name: "foo", path: ".foo", value: "123"
- * - type: JSON_TYPE_ARRAY_START,  name: "bar", path: ".bar", value: NULL
- * - type: JSON_TYPE_NUMBER, name: "0", path: ".bar[0]", value: "1"
- * - type: JSON_TYPE_NUMBER, name: "1", path: ".bar[1]", value: "2"
- * - type: JSON_TYPE_OBJECT_START, name: "2", path: ".bar[2]", value: NULL
- * - type: JSON_TYPE_TRUE, name: "baz", path: ".bar[2].baz", value: "true"
- * - type: JSON_TYPE_OBJECT_END, name: NULL, path: ".bar[2]", value: "{ \"baz\":
- *true }"
- * - type: JSON_TYPE_ARRAY_END, name: NULL, path: ".bar", value: "[ 1, 2, {
- *\"baz\": true } ]"
- * - type: JSON_TYPE_OBJECT_END, name: NULL, path: "", value: "{ \"foo\": 123,
- *\"bar\": [ 1, 2, { \"baz\": true } ] }"
- */
-typedef void (*json_walk_callback_t)(void *callback_data, const char *name,
-                                     size_t name_len, const char *path,
-                                     const struct json_token *token);
-
-/*
- * Parse `json_string`, invoking `callback` in a way similar to SAX parsers;
- * see `json_walk_callback_t`.
- * Return number of processed bytes, or a negative error code.
- */
-int json_walk(const char *json_string, int json_string_length,
-              json_walk_callback_t callback, void *callback_data);
-
-/*
- * JSON generation API.
- * struct json_out abstracts output, allowing alternative printing plugins.
- */
-struct json_out {
-  int (*printer)(struct json_out *, const char *str, size_t len);
-  union {
-    struct {
-      char *buf;
-      size_t size;
-      size_t len;
-    } buf;
-    void *data;
-    FILE *fp;
-  } u;
-};
-
-extern int json_printer_buf(struct json_out *, const char *, size_t);
-extern int json_printer_file(struct json_out *, const char *, size_t);
-
-#define JSON_OUT_BUF(buf, len) \
-  {                            \
-    json_printer_buf, {        \
-      { buf, len, 0 }          \
-    }                          \
-  }
-#define JSON_OUT_FILE(fp)   \
-  {                         \
-    json_printer_file, {    \
-      { (char *) fp, 0, 0 } \
-    }                       \
-  }
-
-typedef int (*json_printf_callback_t)(struct json_out *, va_list *ap);
-
-/*
- * Generate formatted output into a given sting buffer.
- * This is a superset of printf() function, with extra format specifiers:
- *  - `%B` print json boolean, `true` or `false`. Accepts an `int`.
- *  - `%Q` print quoted escaped string or `null`. Accepts a `const char *`.
- *  - `%.*Q` same as `%Q`, but with length. Accepts `int`, `const char *`
- *  - `%V` print quoted base64-encoded string. Accepts a `const char *`, `int`.
- *  - `%H` print quoted hex-encoded string. Accepts a `int`, `const char *`.
- *  - `%M` invokes a json_printf_callback_t function. That callback function
- *  can consume more parameters.
- *
- * Return number of bytes printed. If the return value is bigger than the
- * supplied buffer, that is an indicator of overflow. In the overflow case,
- * overflown bytes are not printed.
- */
-int json_printf(struct json_out *, const char *fmt, ...);
-int json_vprintf(struct json_out *, const char *fmt, va_list ap);
-
-/*
- * Same as json_printf, but prints to a file.
- * File is created if does not exist. File is truncated if already exists.
- */
-int json_fprintf(const char *file_name, const char *fmt, ...);
-int json_vfprintf(const char *file_name, const char *fmt, va_list ap);
-
-/*
- * Print JSON into an allocated 0-terminated string.
- * Return allocated string, or NULL on error.
- * Example:
- *
- * ```c
- *   char *str = json_asprintf("{a:%H}", 3, "abc");
- *   printf("%s\n", str);  // Prints "616263"
- *   free(str);
- * ```
- */
-char *json_asprintf(const char *fmt, ...);
-char *json_vasprintf(const char *fmt, va_list ap);
-
-/*
- * Helper %M callback that prints contiguous C arrays.
- * Consumes void *array_ptr, size_t array_size, size_t elem_size, char *fmt
- * Return number of bytes printed.
- */
-int json_printf_array(struct json_out *, va_list *ap);
-
-/*
- * Scan JSON string `str`, performing scanf-like conversions according to `fmt`.
- * This is a `scanf()` - like function, with following differences:
- *
- * 1. Object keys in the format string may be not quoted, e.g. "{key: %d}"
- * 2. Order of keys in an object is irrelevant.
- * 3. Several extra format specifiers are supported:
- *    - %B: consumes `int *` (or `char *`, if `sizeof(bool) == sizeof(char)`),
- *       expects boolean `true` or `false`.
- *    - %Q: consumes `char **`, expects quoted, JSON-encoded string. Scanned
- *       string is malloc-ed, caller must free() the string.
- *    - %V: consumes `char **`, `int *`. Expects base64-encoded string.
- *       Result string is base64-decoded, malloced and NUL-terminated.
- *       The length of result string is stored in `int *` placeholder.
- *       Caller must free() the result.
- *    - %H: consumes `int *`, `char **`.
- *       Expects a hex-encoded string, e.g. "fa014f".
- *       Result string is hex-decoded, malloced and NUL-terminated.
- *       The length of the result string is stored in `int *` placeholder.
- *       Caller must free() the result.
- *    - %M: consumes custom scanning function pointer and
- *       `void *user_data` parameter - see json_scanner_t definition.
- *    - %T: consumes `struct json_token *`, fills it out with matched token.
- *
- * Return number of elements successfully scanned & converted.
- * Negative number means scan error.
- */
-int json_scanf(const char *str, int str_len, const char *fmt, ...);
-int json_vscanf(const char *str, int str_len, const char *fmt, va_list ap);
-
-/* json_scanf's %M handler  */
-typedef void (*json_scanner_t)(const char *str, int len, void *user_data);
-
-/*
- * Helper function to scan array item with given path and index.
- * Fills `token` with the matched JSON token.
- * Return -1 if no array element found, otherwise non-negative token length.
- */
-int json_scanf_array_elem(const char *s, int len, const char *path, int index,
-                          struct json_token *token);
-
-/*
- * Unescape JSON-encoded string src,slen into dst, dlen.
- * src and dst may overlap.
- * If destination buffer is too small (or zero-length), result string is not
- * written but the length is counted nevertheless (similar to snprintf).
- * Return the length of unescaped string in bytes.
- */
-int json_unescape(const char *src, int slen, char *dst, int dlen);
-
-/*
- * Escape a string `str`, `str_len` into the printer `out`.
- * Return the number of bytes printed.
- */
-int json_escape(struct json_out *out, const char *str, size_t str_len);
-
-/*
- * Read the whole file in memory.
- * Return malloc-ed file content, or NULL on error. The caller must free().
- */
-char *json_fread(const char *file_name);
-
-/*
- * Update given JSON string `s,len` by changing the value at given `json_path`.
- * The result is saved to `out`. If `json_fmt` == NULL, that deletes the key.
- * If path is not present, missing keys are added. Array path without an
- * index pushes a value to the end of an array.
- * Return 1 if the string was changed, 0 otherwise.
- *
- * Example:  s is a JSON string { "a": 1, "b": [ 2 ] }
- *   json_setf(s, len, out, ".a", "7");     // { "a": 7, "b": [ 2 ] }
- *   json_setf(s, len, out, ".b", "7");     // { "a": 1, "b": 7 }
- *   json_setf(s, len, out, ".b[]", "7");   // { "a": 1, "b": [ 2,7 ] }
- *   json_setf(s, len, out, ".b", NULL);    // { "a": 1 }
- */
-int json_setf(const char *s, int len, struct json_out *out,
-              const char *json_path, const char *json_fmt, ...);
-
-int json_vsetf(const char *s, int len, struct json_out *out,
-               const char *json_path, const char *json_fmt, va_list ap);
-
-/*
- * Pretty-print JSON string `s,len` into `out`.
- * Return number of processed bytes in `s`.
- */
-int json_prettify(const char *s, int len, struct json_out *out);
-
-/*
- * Prettify JSON file `file_name`.
- * Return number of processed bytes, or negative number of error.
- * On error, file content is not modified.
- */
-int json_prettify_file(const char *file_name);
-
-/*
- * Iterate over an object at given JSON `path`.
- * On each iteration, fill the `key` and `val` tokens. It is OK to pass NULL
- * for `key`, or `val`, in which case they won't be populated.
- * Return an opaque value suitable for the next iteration, or NULL when done.
- *
- * Example:
- *
- * ```c
- * void *h = NULL;
- * struct json_token key, val;
- * while ((h = json_next_key(s, len, h, ".foo", &key, &val)) != NULL) {
- *   printf("[%.*s] -> [%.*s]\n", key.len, key.ptr, val.len, val.ptr);
- * }
- * ```
- */
-void *json_next_key(const char *s, int len, void *handle, const char *path,
-                    struct json_token *key, struct json_token *val);
-
-/*
- * Iterate over an array at given JSON `path`.
- * Similar to `json_next_key`, but fills array index `idx` instead of `key`.
- */
-void *json_next_elem(const char *s, int len, void *handle, const char *path,
-                     int *idx, struct json_token *val);
-
-#ifndef JSON_MAX_PATH_LEN
-#define JSON_MAX_PATH_LEN 256
-#endif
-
-#ifndef JSON_MINIMAL
-#define JSON_MINIMAL 0
-#endif
-
-#ifndef JSON_ENABLE_BASE64
-#define JSON_ENABLE_BASE64 !JSON_MINIMAL
-#endif
-
-#ifndef JSON_ENABLE_HEX
-#define JSON_ENABLE_HEX !JSON_MINIMAL
-#endif
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
-
-#endif /* CS_FROZEN_FROZEN_H_ */
-#ifdef MJS_MODULE_LINES
 #line 1 "src/ffi/ffi.h"
 #endif
 
 #ifndef MJS_FFI_FFI_H_
 #define MJS_FFI_FFI_H_
 
-/* Amalgamated: #include "common/platform.h" */
+#include "common/platform.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -2633,9 +120,9 @@ void ffi_set_float(struct ffi_arg *arg, float v);
 #define CS_ENABLE_STDIO 1
 #endif
 
-/* Amalgamated: #include "common/cs_dbg.h" */
-/* Amalgamated: #include "common/cs_file.h" */
-/* Amalgamated: #include "common/mbuf.h" */
+#include "common/cs_dbg.h"
+#include "common/cs_file.h"
+#include "common/mbuf.h"
 
 #if defined(_WIN32) && _MSC_VER < 1700
 typedef signed char int8_t;
@@ -2673,6 +160,316 @@ typedef unsigned long uintptr_t;
 
 #endif /* MJS_INTERNAL_H_ */
 #ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_features.h"
+#endif
+
+#ifndef MJS_FEATURES_H_
+#define MJS_FEATURES_H_
+
+#if !defined(MJS_AGGRESSIVE_GC)
+#define MJS_AGGRESSIVE_GC 0
+#endif
+
+#if !defined(MJS_MEMORY_STATS)
+#define MJS_MEMORY_STATS 0
+#endif
+
+/*
+ * MJS_GENERATE_JSC: if enabled, and if mmapping is also enabled (CS_MMAP),
+ * then execution of any .js file will result in creation of a .jsc file with
+ * precompiled bcode, and this .jsc file will be mmapped, instead of keeping
+ * bcode in RAM.
+ *
+ * By default it's enabled (provided that CS_MMAP is defined)
+ */
+#if !defined(MJS_GENERATE_JSC)
+#if defined(CS_MMAP)
+#define MJS_GENERATE_JSC 1
+#else
+#define MJS_GENERATE_JSC 0
+#endif
+#endif
+
+#endif /* MJS_FEATURES_H_ */
+#ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_core_public.h"
+#endif
+
+#ifndef MJS_CORE_PUBLIC_H_
+#define MJS_CORE_PUBLIC_H_
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1700
+#include <stdint.h>
+#else
+typedef unsigned __int64 uint64_t;
+typedef int int32_t;
+typedef unsigned char uint8_t;
+#endif
+#include <stdio.h>
+#include <stddef.h>
+/* Amalgamated: #include "mjs_features.h" */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#define MJS_ENABLE_DEBUG 1
+
+/*
+ *  Double-precision floating-point number, IEEE 754
+ *
+ *  64 bit (8 bytes) in total
+ *  1  bit sign
+ *  11 bits exponent
+ *  52 bits mantissa
+ *      7         6        5        4        3        2        1        0
+ *  seeeeeee|eeeemmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm
+ *
+ * If an exponent is all-1 and mantissa is all-0, then it is an INFINITY:
+ *  11111111|11110000|00000000|00000000|00000000|00000000|00000000|00000000
+ *
+ * If an exponent is all-1 and mantissa's MSB is 1, it is a quiet NaN:
+ *  11111111|11111000|00000000|00000000|00000000|00000000|00000000|00000000
+ *
+ *  MJS NaN-packing:
+ *    sign and exponent is 0xfff
+ *    4 bits specify type (tag), must be non-zero
+ *    48 bits specify value
+ *
+ *  11111111|1111tttt|vvvvvvvv|vvvvvvvv|vvvvvvvv|vvvvvvvv|vvvvvvvv|vvvvvvvv
+ *   NaN marker |type|  48-bit placeholder for values: pointers, strings
+ *
+ * On 64-bit platforms, pointers are really 48 bit only, so they can fit,
+ * provided they are sign extended
+ */
+
+typedef uint64_t mjs_val_t;
+
+/* This if-0 is a dirty workaround to force etags to pick `struct mjs` */
+#if 0
+/* Opaque structure. MJS engine context. */
+struct mjs {
+  /* ... */
+};
+#endif
+
+struct mjs;
+
+typedef enum mjs_err {
+  MJS_OK,
+  MJS_SYNTAX_ERROR,
+  MJS_REFERENCE_ERROR,
+  MJS_TYPE_ERROR,
+  MJS_OUT_OF_MEMORY,
+  MJS_INTERNAL_ERROR,
+  MJS_NOT_IMPLEMENTED_ERROR,
+  MJS_FILE_READ_ERROR,
+  MJS_BAD_ARGS_ERROR,
+
+  MJS_ERRS_CNT
+} mjs_err_t;
+struct mjs;
+
+/* Create MJS instance */
+struct mjs *mjs_create();
+
+struct mjs_create_opts {
+  /* use non-default bytecode definition file, testing-only */
+  const struct bf_code *code;
+};
+
+/*
+ * Like `msj_create()`, but allows to customize initial MJS state, see `struct
+ * mjs_create_opts`.
+ */
+struct mjs *mjs_create_opt(struct mjs_create_opts opts);
+
+/* Destroy MJS instance */
+void mjs_destroy(struct mjs *mjs);
+
+mjs_val_t mjs_get_global(struct mjs *mjs);
+
+/*
+ * Tells the GC about an MJS value variable/field owned by C code.
+ *
+ * The user's C code should own mjs_val_t variables if the value's lifetime
+ * crosses any invocation of `mjs_exec()` and friends, including `mjs_call()`.
+ *
+ * The registration of the variable prevents the GC from mistakenly treat the
+ * object as garbage.
+ *
+ * User code should also explicitly disown the variables with `mjs_disown()`
+ * once it goes out of scope or the structure containing the mjs_val_t field is
+ * freed.
+ *
+ * Consider the following examples:
+ *
+ * Correct (owning is not necessary):
+ * ```c
+ * mjs_val_t res;
+ * mjs_exec(mjs, "....some script", &res);
+ * // ... use res somehow
+ *
+ * mjs_val_t res;
+ * mjs_exec(mjs, "....some script2", &res);
+ * // ... use new res somehow
+ * ```
+ *
+ * WRONG:
+ * ```c
+ * mjs_val_t res1;
+ * mjs_exec(mjs, "....some script", &res1);
+ *
+ * mjs_val_t res2;
+ * mjs_exec(mjs, "....some script2", &res2);
+ *
+ * // ... use res1 (WRONG!) and res2
+ * ```
+ *
+ * The code above is wrong, because after the second invocation of
+ * `mjs_exec()`, the value of `res1` is invalidated.
+ *
+ * Correct (res1 is owned)
+ * ```c
+ * mjs_val_t res1 = MJS_UNDEFINED;
+ * mjs_own(mjs, &res1);
+ * mjs_exec(mjs, "....some script", &res1);
+ *
+ * mjs_val_t res2 = MJS_UNDEFINED;
+ * mjs_exec(mjs, "....some script2", &res2);
+ *
+ * // ... use res1 and res2
+ * mjs_disown(mjs, &res1);
+ * ```
+ *
+ * NOTE that we explicly initialized `res1` to a valid value before owning it
+ * (in this case, the value is `MJS_UNDEFINED`). Owning an uninitialized
+ * variable is an undefined behaviour.
+ *
+ * Of course, it's not an error to own a variable even if it's not mandatory:
+ * e.g. in the last example we could own both `res1` and `res2`. Probably it
+ * would help us in the future, when we refactor the code so that `res2` has to
+ * be owned, and we could forget to do that.
+ *
+ * Also, if the user code has some C function called from MJS, and in this C
+ * function some MJS value (`mjs_val_t`) needs to be stored somewhere and to
+ * stay alive after the C function has returned, it also needs to be properly
+ * owned.
+ */
+void mjs_own(struct mjs *mjs, mjs_val_t *v);
+
+/*
+ * Disowns the value previously owned by `mjs_own()`.
+ *
+ * Returns 1 if value is found, 0 otherwise.
+ */
+int mjs_disown(struct mjs *mjs, mjs_val_t *v);
+
+mjs_err_t mjs_set_errorf(struct mjs *mjs, mjs_err_t err, const char *fmt, ...);
+
+/*
+ * If there is no error message already set, then it's equal to
+ * `mjs_set_errorf()`.
+ *
+ * Otherwise, an old message gets prepended with the new one, followed by a
+ * colon. (the previously set error code is kept)
+ */
+mjs_err_t mjs_prepend_errorf(struct mjs *mjs, mjs_err_t err, const char *fmt,
+                             ...);
+
+/*
+ * Print the last error details. If print_stack_trace is non-zero, also
+ * print stack trace. `msg` is the message which gets prepended to the actual
+ * error message, if it's NULL, then "MJS error" is used.
+ */
+void mjs_print_error(struct mjs *mjs, FILE *fp, const char *msg,
+                     int print_stack_trace);
+
+/*
+ * return a string representation of an error.
+ * the error string might be overwritten by calls to `mjs_set_errorf`.
+ */
+const char *mjs_strerror(struct mjs *mjs, enum mjs_err err);
+
+/*
+ * Sets whether *.jsc files are generated when *.js file is executed. By
+ * default it's 0.
+ *
+ * If either `MJS_GENERATE_JSC` or `CS_MMAP` is off, then this function has no
+ * effect.
+ */
+void mjs_set_generate_jsc(struct mjs *mjs, int generate_jsc);
+
+/*
+ * When invoked from a cfunction, returns number of arguments passed to the
+ * current JS function call.
+ */
+int mjs_nargs(struct mjs *mjs);
+
+/*
+ * When invoked from a cfunction, returns n-th argument to the current JS
+ * function call.
+ */
+mjs_val_t mjs_arg(struct mjs *mjs, int n);
+
+/*
+ * Sets return value for the current JS function call.
+ */
+void mjs_return(struct mjs *mjs, mjs_val_t v);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_CORE_PUBLIC_H_ */
+#ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_array_public.h"
+#endif
+
+/*
+ * === Arrays
+ */
+
+#ifndef MJS_ARRAY_PUBLIC_H_
+#define MJS_ARRAY_PUBLIC_H_
+
+/* Amalgamated: #include "mjs_core_public.h" */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/* Make an empty array object */
+mjs_val_t mjs_mk_array(struct mjs *mjs);
+
+/* Returns length on an array. If `arr` is not an array, 0 is returned. */
+unsigned long mjs_array_length(struct mjs *mjs, mjs_val_t arr);
+
+/* Insert value `v` in array `arr` at the end of the array. */
+mjs_err_t mjs_array_push(struct mjs *mjs, mjs_val_t arr, mjs_val_t v);
+
+/*
+ * Return array member at index `index`. If `index` is out of bounds, undefined
+ * is returned.
+ */
+mjs_val_t mjs_array_get(struct mjs *, mjs_val_t arr, unsigned long index);
+
+/* Insert value `v` into `arr` at index `index`. */
+mjs_err_t mjs_array_set(struct mjs *mjs, mjs_val_t arr, unsigned long index,
+                        mjs_val_t v);
+
+/* Returns true if the given value is an array */
+int mjs_is_array(mjs_val_t v);
+
+/* Delete value in array `arr` at index `index`, if it exists. */
+void mjs_array_del(struct mjs *mjs, mjs_val_t arr, unsigned long index);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_ARRAY_PUBLIC_H_ */
+#ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_array.h"
 #endif
 
@@ -2698,6 +495,43 @@ MJS_PRIVATE void mjs_array_push_internal(struct mjs *mjs);
 #endif /* __cplusplus */
 
 #endif /* MJS_ARRAY_H_ */
+#ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_ffi_public.h"
+#endif
+
+#ifndef MJS_FFI_PUBLIC_H_
+#define MJS_FFI_PUBLIC_H_
+
+/* Amalgamated: #include "mjs_core_public.h" */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+enum mjs_ffi_ctype {
+  MJS_FFI_CTYPE_NONE,
+  MJS_FFI_CTYPE_USERDATA,
+  MJS_FFI_CTYPE_CALLBACK,
+  MJS_FFI_CTYPE_INT,
+  MJS_FFI_CTYPE_BOOL,
+  MJS_FFI_CTYPE_DOUBLE,
+  MJS_FFI_CTYPE_FLOAT,
+  MJS_FFI_CTYPE_CHAR_PTR,
+  MJS_FFI_CTYPE_VOID_PTR,
+  MJS_FFI_CTYPE_STRUCT_MG_STR_PTR,
+  MJS_FFI_CTYPE_STRUCT_MG_STR,
+  MJS_FFI_CTYPE_INVALID,
+};
+
+typedef void *(mjs_ffi_resolver_t)(void *handle, const char *symbol);
+
+void mjs_set_ffi_resolver(struct mjs *mjs, mjs_ffi_resolver_t *dlsym);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_FFI_PUBLIC_H_ */
 #ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_ffi.h"
 #endif
@@ -3162,6 +996,129 @@ MJS_PRIVATE int mjs_is_truthy(struct mjs *mjs, mjs_val_t v);
 
 #endif /* MJS_CONVERSION_H_ */
 #ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_object_public.h"
+#endif
+
+#ifndef MJS_OBJECT_PUBLIC_H_
+#define MJS_OBJECT_PUBLIC_H_
+
+#include <stddef.h>
+/* Amalgamated: #include "mjs_core_public.h" */
+/* Amalgamated: #include "mjs_ffi_public.h" */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*
+ * Returns true if the given value is an object or array.
+ */
+int mjs_is_object(mjs_val_t v);
+
+/* Make an empty object */
+mjs_val_t mjs_mk_object(struct mjs *mjs);
+
+/* Field types for struct-object conversion. */
+enum mjs_struct_field_type {
+  MJS_STRUCT_FIELD_TYPE_INVALID,
+  MJS_STRUCT_FIELD_TYPE_STRUCT,     /* Struct, arg points to def. */
+  MJS_STRUCT_FIELD_TYPE_STRUCT_PTR, /* Ptr to struct, arg points to def. */
+  MJS_STRUCT_FIELD_TYPE_INT,
+  MJS_STRUCT_FIELD_TYPE_BOOL,
+  MJS_STRUCT_FIELD_TYPE_DOUBLE,
+  MJS_STRUCT_FIELD_TYPE_FLOAT,
+  MJS_STRUCT_FIELD_TYPE_CHAR_PTR,   /* NUL-terminated string. */
+  MJS_STRUCT_FIELD_TYPE_VOID_PTR,   /* Converted to foreign ptr. */
+  MJS_STRUCT_FIELD_TYPE_MG_STR_PTR, /* Converted to string. */
+  MJS_STRUCT_FIELD_TYPE_MG_STR,     /* Converted to string. */
+  MJS_STRUCT_FIELD_TYPE_DATA,       /* Data, arg is length, becomes string. */
+  MJS_STRUCT_FIELD_TYPE_INT8,
+  MJS_STRUCT_FIELD_TYPE_INT16,
+  MJS_STRUCT_FIELD_TYPE_UINT8,
+  MJS_STRUCT_FIELD_TYPE_UINT16,
+  /*
+   * User-provided function. Arg is a pointer to function that takes void *
+   * (pointer to field within the struct) and returns mjs_val_t:
+   * mjs_val_t field_value(struct mjs *mjs, const void *field_ptr) { ... }
+   */
+  MJS_STRUCT_FIELD_TYPE_CUSTOM,
+};
+
+/* C structure layout descriptor - needed by mjs_struct_to_obj */
+struct mjs_c_struct_member {
+  const char *name;
+  int offset;
+  enum mjs_struct_field_type type;
+  const void *arg; /* Additional argument, used for some types. */
+};
+
+/* Create flat JS object from a C memory descriptor */
+mjs_val_t mjs_struct_to_obj(struct mjs *mjs, const void *base,
+                            const struct mjs_c_struct_member *members);
+
+/*
+ * Lookup property `name` in object `obj`. If `obj` holds no such property,
+ * an `undefined` value is returned.
+ *
+ * If `name_len` is ~0, `name` is assumed to be NUL-terminated and
+ * `strlen(name)` is used.
+ */
+mjs_val_t mjs_get(struct mjs *mjs, mjs_val_t obj, const char *name,
+                  size_t name_len);
+
+/*
+ * Like mjs_get but with a JS string.
+ */
+mjs_val_t mjs_get_v(struct mjs *mjs, mjs_val_t obj, mjs_val_t name);
+
+/*
+ * Like mjs_get_v but lookup the prototype chain.
+ */
+mjs_val_t mjs_get_v_proto(struct mjs *mjs, mjs_val_t obj, mjs_val_t key);
+
+/*
+ * Set object property. Behaves just like JavaScript assignment.
+ */
+mjs_err_t mjs_set(struct mjs *mjs, mjs_val_t obj, const char *name, size_t len,
+                  mjs_val_t val);
+
+/*
+ * Like mjs_set but the name is already a JS string.
+ */
+mjs_err_t mjs_set_v(struct mjs *mjs, mjs_val_t obj, mjs_val_t name,
+                    mjs_val_t val);
+
+/*
+ * Delete own property `name` of the object `obj`. Does not follow the
+ * prototype chain.
+ *
+ * If `name_len` is ~0, `name` is assumed to be NUL-terminated and
+ * `strlen(name)` is used.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int mjs_del(struct mjs *mjs, mjs_val_t obj, const char *name, size_t len);
+
+/*
+ * Iterate over `obj` properties.
+ * First call should set `iterator` to MJS_UNDEFINED.
+ * Return object's key (a string), or MJS_UNDEFINED when no more keys left.
+ * Do not mutate the object during iteration.
+ *
+ * Example:
+ *   mjs_val_t key, iter = MJS_UNDEFINED;
+ *   while ((key = mjs_next(mjs, obj, &iter)) != MJS_UNDEFINED) {
+ *     // Do something with the obj/key ...
+ *   }
+ */
+mjs_val_t mjs_next(struct mjs *mjs, mjs_val_t obj, mjs_val_t *iterator);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_OBJECT_PUBLIC_H_ */
+#ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_object.h"
 #endif
 
@@ -3219,6 +1176,126 @@ MJS_PRIVATE void mjs_op_create_object(struct mjs *mjs);
 
 #endif /* MJS_OBJECT_H_ */
 #ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_primitive_public.h"
+#endif
+
+#ifndef MJS_PRIMITIVE_PUBLIC_H_
+#define MJS_PRIMITIVE_PUBLIC_H_
+
+/* Amalgamated: #include "mjs_core_public.h" */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/* JavaScript `null` value */
+#define MJS_NULL MJS_TAG_NULL
+
+/* JavaScript `undefined` value */
+#define MJS_UNDEFINED MJS_TAG_UNDEFINED
+
+/* Function pointer type used in `mjs_mk_foreign_func`. */
+typedef void (*mjs_func_ptr_t)(void);
+
+/*
+ * Make `null` primitive value.
+ *
+ * NOTE: this function is deprecated and will be removed in future releases.
+ * Use `MJS_NULL` instead.
+ */
+mjs_val_t mjs_mk_null(void);
+
+/* Returns true if given value is a primitive `null` value */
+int mjs_is_null(mjs_val_t v);
+
+/*
+ * Make `undefined` primitive value.
+ *
+ * NOTE: this function is deprecated and will be removed in future releases.
+ * Use `MJS_UNDEFINED` instead.
+ */
+mjs_val_t mjs_mk_undefined(void);
+
+/* Returns true if given value is a primitive `undefined` value */
+int mjs_is_undefined(mjs_val_t v);
+
+/* Make numeric primitive value */
+mjs_val_t mjs_mk_number(struct mjs *mjs, double num);
+
+/*
+ * Returns number value stored in `mjs_val_t` as `double`.
+ *
+ * Returns NaN for non-numbers.
+ */
+double mjs_get_double(struct mjs *mjs, mjs_val_t v);
+
+/*
+ * Returns number value stored in `mjs_val_t` as `int`. If the number value is
+ * not an integer, the fraction part will be discarded.
+ *
+ * If the given value is a non-number, or NaN, the result is undefined.
+ */
+int mjs_get_int(struct mjs *mjs, mjs_val_t v);
+
+/*
+ * Like mjs_get_int but ensures that the returned type
+ * is a 32-bit signed integer.
+ */
+int32_t mjs_get_int32(struct mjs *mjs, mjs_val_t v);
+
+/* Returns true if given value is a primitive number value */
+int mjs_is_number(mjs_val_t v);
+
+/*
+ * Make JavaScript value that holds C/C++ `void *` pointer.
+ *
+ * A foreign value is completely opaque and JS code cannot do anything useful
+ * with it except holding it in properties and passing it around.
+ * It behaves like a sealed object with no properties.
+ *
+ * NOTE:
+ * Only valid pointers (as defined by each supported architecture) will fully
+ * preserved. In particular, all supported 64-bit architectures (x86_64, ARM-64)
+ * actually define a 48-bit virtual address space.
+ * Foreign values will be sign-extended as required, i.e creating a foreign
+ * value of something like `(void *) -1` will work as expected. This is
+ * important because in some 64-bit OSs (e.g. Solaris) the user stack grows
+ * downwards from the end of the address space.
+ *
+ * If you need to store exactly sizeof(void*) bytes of raw data where
+ * `sizeof(void*)` >= 8, please use byte arrays instead.
+ */
+mjs_val_t mjs_mk_foreign(struct mjs *mjs, void *ptr);
+
+/*
+ * Make JavaScript value that holds C/C++ function pointer, similarly to
+ * `mjs_mk_foreign`.
+ */
+mjs_val_t mjs_mk_foreign_func(struct mjs *mjs, mjs_func_ptr_t fn);
+
+/*
+ * Returns `void *` pointer stored in `mjs_val_t`.
+ *
+ * Returns NULL if the value is not a foreign pointer.
+ */
+void *mjs_get_ptr(struct mjs *mjs, mjs_val_t v);
+
+/* Returns true if given value holds `void *` pointer */
+int mjs_is_foreign(mjs_val_t v);
+
+mjs_val_t mjs_mk_boolean(struct mjs *mjs, int v);
+int mjs_get_bool(struct mjs *mjs, mjs_val_t v);
+int mjs_is_boolean(mjs_val_t v);
+
+mjs_val_t mjs_mk_function(struct mjs *mjs, size_t off);
+int mjs_is_function(mjs_val_t v);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_PRIMITIVE_PUBLIC_H_ */
+#ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_primitive.h"
 #endif
 
@@ -3258,6 +1335,83 @@ MJS_PRIVATE void mjs_op_isnan(struct mjs *mjs);
 #endif /* __cplusplus */
 
 #endif /* MJS_PRIMITIVE_H */
+#ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_string_public.h"
+#endif
+
+#ifndef MJS_STRING_PUBLIC_H_
+#define MJS_STRING_PUBLIC_H_
+
+/* Amalgamated: #include "mjs_core_public.h" */
+
+#define MJS_STRING_LITERAL_MAX_LEN 128
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*
+ * Creates a string primitive value.
+ * `str` must point to the utf8 string of length `len`.
+ * If `len` is ~0, `str` is assumed to be NUL-terminated and `strlen(str)` is
+ * used.
+ *
+ * If `copy` is non-zero, the string data is copied and owned by the GC. The
+ * caller can free the string data afterwards. Otherwise (`copy` is zero), the
+ * caller owns the string data, and is responsible for not freeing it while it
+ * is used.
+ */
+mjs_val_t mjs_mk_string(struct mjs *mjs, const char *str, size_t len, int copy);
+
+/* Returns true if given value is a primitive string value */
+int mjs_is_string(mjs_val_t v);
+
+/*
+ * Returns a pointer to the string stored in `mjs_val_t`.
+ *
+ * String length returned in `len`, which is allowed to be NULL. Returns NULL
+ * if the value is not a string.
+ *
+ * JS strings can contain embedded NUL chars and may or may not be NUL
+ * terminated.
+ *
+ * CAUTION: creating new JavaScript object, array, or string may kick in a
+ * garbage collector, which in turn may relocate string data and invalidate
+ * pointer returned by `mjs_get_string()`.
+ *
+ * Short JS strings are embedded inside the `mjs_val_t` value itself. This
+ * is why a pointer to a `mjs_val_t` is required. It also means that the string
+ * data will become invalid once that `mjs_val_t` value goes out of scope.
+ */
+const char *mjs_get_string(struct mjs *mjs, mjs_val_t *v, size_t *len);
+
+/*
+ * Returns a pointer to the string stored in `mjs_val_t`.
+ *
+ * Returns NULL if the value is not a string or if the string is not compatible
+ * with a C string.
+ *
+ * C compatible strings contain exactly one NUL char, in terminal position.
+ *
+ * All strings owned by the MJS engine (see `mjs_mk_string()`) are guaranteed to
+ * be NUL terminated. Out of these, those that don't include embedded NUL chars
+ * are guaranteed to be C compatible.
+ */
+const char *mjs_get_cstring(struct mjs *mjs, mjs_val_t *v);
+
+/*
+ * Returns the standard strcmp comparison code after comparing a JS string a
+ * with a possibly non null-terminated string b. NOTE: the strings are equal
+ * only if their length is equal, i.e. the len field doesn't imply strncmp
+ * behaviour.
+ */
+int mjs_strcmp(struct mjs *mjs, mjs_val_t *a, const char *b, size_t len);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_STRING_PUBLIC_H_ */
 #ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_string.h"
 #endif
@@ -3302,13 +1456,62 @@ MJS_PRIVATE void mjs_string_char_code_at(struct mjs *mjs);
 
 #endif /* MJS_STRING_H_ */
 #ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_util_public.h"
+#endif
+
+#ifndef MJS_UTIL_PUBLIC_H_
+#define MJS_UTIL_PUBLIC_H_
+
+/* Amalgamated: #include "mjs_core_public.h" */
+#include <stdio.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+const char *mjs_typeof(mjs_val_t v);
+
+void mjs_fprintf(mjs_val_t v, struct mjs *mjs, FILE *fp);
+void mjs_sprintf(mjs_val_t v, struct mjs *mjs, char *buf, size_t buflen);
+
+#if MJS_ENABLE_DEBUG
+
+void mjs_disasm(const uint8_t *code, size_t len);
+void mjs_dump(struct mjs *mjs, int do_disasm);
+
+#endif
+
+/*
+ * Returns the filename corresponding to the given bcode offset.
+ */
+const char *mjs_get_bcode_filename_by_offset(struct mjs *mjs, int offset);
+
+/*
+ * Returns the line number corresponding to the given bcode offset.
+ */
+int mjs_get_lineno_by_offset(struct mjs *mjs, int offset);
+
+/*
+ * Returns bcode offset of the corresponding call frame cf_num, where 0 means
+ * the currently executing function, 1 means the first return address, etc.
+ *
+ * If given cf_num is too large, -1 is returned.
+ */
+int mjs_get_offset_by_call_frame_num(struct mjs *mjs, int cf_num);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_UTIL_PUBLIC_H_ */
+#ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_util.h"
 #endif
 
 #ifndef MJS_UTIL_H_
 #define MJS_UTIL_H_
 
-/* Amalgamated: #include "frozen.h" */
+#include "frozen.h"
 /* Amalgamated: #include "mjs_core.h" */
 /* Amalgamated: #include "mjs_util_public.h" */
 
@@ -3352,52 +1555,6 @@ void mjs_jprintf(mjs_val_t v, struct mjs *mjs, struct json_out *out);
 #endif /* __cplusplus */
 
 #endif /* MJS_UTIL_H_ */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_varint.h"
-#endif
-
-#ifndef CS_COMMON_CS_VARINT_H_
-#define CS_COMMON_CS_VARINT_H_
-
-#if defined(_WIN32) && _MSC_VER < 1700
-typedef unsigned char uint8_t;
-typedef unsigned __int64 uint64_t;
-#else
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* Returns number of bytes required to encode `num`. */
-size_t cs_varint_llen(uint64_t num);
-
-/*
- * Encodes `num` into `buf`.
- * Returns number of bytes required to encode `num`.
- * Note: return value may be greater than `buf_size` but the function will only
- * write `buf_size` bytes.
- */
-size_t cs_varint_encode(uint64_t num, uint8_t *buf, size_t buf_size);
-
-/*
- * Decodes varint stored in `buf`.
- * Stores the number of bytes consumed into `llen`.
- * If there aren't enough bytes in `buf` to decode a number, returns false.
- */
-bool cs_varint_decode(const uint8_t *buf, size_t buf_size, uint64_t *num,
-                      size_t *llen);
-
-uint64_t cs_varint_decode_unsafe(const uint8_t *buf, int *llen);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* CS_COMMON_CS_VARINT_H_ */
 #ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_bcode.h"
 #endif
@@ -3676,6 +1833,35 @@ void mjs_mem_set_int(void *ptr, int val, int size, int bigendian);
 
 #endif /* MJS_DATAVIEW_H_ */
 #ifdef MJS_MODULE_LINES
+#line 1 "src/mjs_exec_public.h"
+#endif
+
+#ifndef MJS_EXEC_PUBLIC_H_
+#define MJS_EXEC_PUBLIC_H_
+
+/* Amalgamated: #include "mjs_core_public.h" */
+#include <stdio.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+mjs_err_t mjs_exec(struct mjs *, const char *src, mjs_val_t *res);
+mjs_err_t mjs_exec_buf(struct mjs *, const char *src, size_t, mjs_val_t *res);
+
+mjs_err_t mjs_exec_file(struct mjs *mjs, const char *path, mjs_val_t *res);
+mjs_err_t mjs_apply(struct mjs *mjs, mjs_val_t *res, mjs_val_t func,
+                    mjs_val_t this_val, int nargs, mjs_val_t *args);
+mjs_err_t mjs_call(struct mjs *mjs, mjs_val_t *res, mjs_val_t func,
+                   mjs_val_t this_val, int nargs, ...);
+mjs_val_t mjs_get_this(struct mjs *mjs);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* MJS_EXEC_PUBLIC_H_ */
+#ifdef MJS_MODULE_LINES
 #line 1 "src/mjs_exec.h"
 #endif
 
@@ -3771,2529 +1957,6 @@ mjs_parse(const char *path, const char *buf, struct mjs *);
 #endif /* __cplusplus */
 
 #endif /* MJS_PARSER_H */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_dbg.c"
-#endif
-
-/* Amalgamated: #include "common/cs_dbg.h" */
-
-#include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
-
-/* Amalgamated: #include "common/cs_time.h" */
-/* Amalgamated: #include "common/str_util.h" */
-
-enum cs_log_level cs_log_level WEAK =
-#if CS_ENABLE_DEBUG
-    LL_VERBOSE_DEBUG;
-#else
-    LL_ERROR;
-#endif
-
-#if CS_ENABLE_STDIO
-static char *s_file_level = NULL;
-
-void cs_log_set_file_level(const char *file_level) WEAK;
-
-FILE *cs_log_file WEAK = NULL;
-
-#if CS_LOG_ENABLE_TS_DIFF
-double cs_log_ts WEAK;
-#endif
-
-enum cs_log_level cs_log_cur_msg_level WEAK = LL_NONE;
-
-void cs_log_set_file_level(const char *file_level) {
-  char *fl = s_file_level;
-  if (file_level != NULL) {
-    s_file_level = strdup(file_level);
-  } else {
-    s_file_level = NULL;
-  }
-  free(fl);
-}
-
-int cs_log_print_prefix(enum cs_log_level level, const char *file, int ln) WEAK;
-int cs_log_print_prefix(enum cs_log_level level, const char *file, int ln) {
-  char prefix[CS_LOG_PREFIX_LEN], *q;
-  const char *p;
-  size_t fl = 0, ll = 0, pl = 0;
-
-  if (level > cs_log_level && s_file_level == NULL) return 0;
-
-  p = file + strlen(file);
-
-  while (p != file) {
-    const char c = *(p - 1);
-    if (c == '/' || c == '\\') break;
-    p--;
-    fl++;
-  }
-
-  ll = (ln < 10000 ? (ln < 1000 ? (ln < 100 ? (ln < 10 ? 1 : 2) : 3) : 4) : 5);
-  if (fl > (sizeof(prefix) - ll - 2)) fl = (sizeof(prefix) - ll - 2);
-
-  pl = fl + 1 + ll;
-  memcpy(prefix, p, fl);
-  q = prefix + pl;
-  memset(q, ' ', sizeof(prefix) - pl);
-  do {
-    *(--q) = '0' + (ln % 10);
-    ln /= 10;
-  } while (ln > 0);
-  *(--q) = ':';
-
-  if (s_file_level != NULL) {
-    enum cs_log_level pll = cs_log_level;
-    struct mg_str fl = mg_mk_str(s_file_level), ps = MG_MK_STR_N(prefix, pl);
-    struct mg_str k, v;
-    while ((fl = mg_next_comma_list_entry_n(fl, &k, &v)).p != NULL) {
-      bool yes = !(!mg_str_starts_with(ps, k) || v.len == 0);
-      if (!yes) continue;
-      pll = (enum cs_log_level)(*v.p - '0');
-      break;
-    }
-    if (level > pll) return 0;
-  }
-
-  if (cs_log_file == NULL) cs_log_file = stderr;
-  cs_log_cur_msg_level = level;
-  fwrite(prefix, 1, sizeof(prefix), cs_log_file);
-#if CS_LOG_ENABLE_TS_DIFF
-  {
-    double now = cs_time();
-    fprintf(cs_log_file, "%7u ", (unsigned int) ((now - cs_log_ts) * 1000000));
-    cs_log_ts = now;
-  }
-#endif
-  return 1;
-}
-
-void cs_log_printf(const char *fmt, ...) WEAK;
-void cs_log_printf(const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  vfprintf(cs_log_file, fmt, ap);
-  va_end(ap);
-  fputc('\n', cs_log_file);
-  fflush(cs_log_file);
-  cs_log_cur_msg_level = LL_NONE;
-}
-
-void cs_log_set_file(FILE *file) WEAK;
-void cs_log_set_file(FILE *file) {
-  cs_log_file = file;
-}
-
-#else
-
-void cs_log_set_file_level(const char *file_level) {
-  (void) file_level;
-}
-
-#endif /* CS_ENABLE_STDIO */
-
-void cs_log_set_level(enum cs_log_level level) WEAK;
-void cs_log_set_level(enum cs_log_level level) {
-  cs_log_level = level;
-#if CS_LOG_ENABLE_TS_DIFF && CS_ENABLE_STDIO
-  cs_log_ts = cs_time();
-#endif
-}
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_file.c"
-#endif
-
-/* Amalgamated: #include "common/cs_file.h" */
-
-#include <stdio.h>
-#include <stdlib.h>
-
-#ifdef CS_MMAP
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#endif
-
-#ifndef EXCLUDE_COMMON
-char *cs_read_file(const char *path, size_t *size) WEAK;
-char *cs_read_file(const char *path, size_t *size) {
-  FILE *fp;
-  char *data = NULL;
-  if ((fp = fopen(path, "rb")) == NULL) {
-  } else if (fseek(fp, 0, SEEK_END) != 0) {
-    fclose(fp);
-  } else {
-    *size = ftell(fp);
-    data = (char *) malloc(*size + 1);
-    if (data != NULL) {
-      fseek(fp, 0, SEEK_SET); /* Some platforms might not have rewind(), Oo */
-      if (fread(data, 1, *size, fp) != *size) {
-        free(data);
-        return NULL;
-      }
-      data[*size] = '\0';
-    }
-    fclose(fp);
-  }
-  return data;
-}
-#endif /* EXCLUDE_COMMON */
-
-#ifdef CS_MMAP
-char *cs_mmap_file(const char *path, size_t *size) WEAK;
-char *cs_mmap_file(const char *path, size_t *size) {
-  char *r;
-  int fd = open(path, O_RDONLY, 0);
-  struct stat st;
-  if (fd < 0) return NULL;
-  fstat(fd, &st);
-  *size = (size_t) st.st_size;
-  r = (char *) mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-  if (r == MAP_FAILED) return NULL;
-  return r;
-}
-#endif
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/cs_varint.c"
-#endif
-
-/* Amalgamated: #include "cs_varint.h" */
-
-size_t cs_varint_llen(uint64_t num) {
-  size_t llen = 0;
-
-  do {
-    llen++;
-  } while (num >>= 7);
-
-  return llen;
-}
-
-size_t cs_varint_encode(uint64_t num, uint8_t *buf, size_t buf_size) {
-  size_t llen = 0;
-
-  do {
-    uint8_t byte = num & 0x7f;
-    num >>= 7;
-    if (num != 0) byte |= 0x80;
-    if (llen < buf_size) *buf++ = byte;
-    llen++;
-  } while (num != 0);
-
-  return llen;
-}
-
-bool cs_varint_decode(const uint8_t *buf, size_t buf_size, uint64_t *num,
-                      size_t *llen) {
-  size_t i = 0, shift = 0;
-  uint64_t n = 0;
-
-  do {
-    if (i == buf_size || i == (8 * sizeof(*num) / 7 + 1)) return false;
-    /*
-     * Each byte of varint contains 7 bits, in little endian order.
-     * MSB is a continuation bit: it tells whether next byte is used.
-     */
-    n |= ((uint64_t)(buf[i] & 0x7f)) << shift;
-    /*
-     * First we increment i, then check whether it is within boundary and
-     * whether decoded byte had continuation bit set.
-     */
-    i++;
-    shift += 7;
-  } while (shift < sizeof(uint64_t) * 8 && (buf[i - 1] & 0x80));
-
-  *num = n;
-  *llen = i;
-
-  return true;
-}
-
-uint64_t cs_varint_decode_unsafe(const uint8_t *buf, int *llen) {
-  uint64_t v;
-  size_t l;
-  cs_varint_decode(buf, ~0, &v, &l);
-  *llen = l;
-  return v;
-}
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/mbuf.c"
-#endif
-
-#ifndef EXCLUDE_COMMON
-
-#include <assert.h>
-#include <string.h>
-/* Amalgamated: #include "common/mbuf.h" */
-
-#ifndef MBUF_REALLOC
-#define MBUF_REALLOC realloc
-#endif
-
-#ifndef MBUF_FREE
-#define MBUF_FREE free
-#endif
-
-void mbuf_init(struct mbuf *mbuf, size_t initial_size) WEAK;
-void mbuf_init(struct mbuf *mbuf, size_t initial_size) {
-  mbuf->len = mbuf->size = 0;
-  mbuf->buf = NULL;
-  mbuf_resize(mbuf, initial_size);
-}
-
-void mbuf_free(struct mbuf *mbuf) WEAK;
-void mbuf_free(struct mbuf *mbuf) {
-  if (mbuf->buf != NULL) {
-    MBUF_FREE(mbuf->buf);
-    mbuf_init(mbuf, 0);
-  }
-}
-
-void mbuf_resize(struct mbuf *a, size_t new_size) WEAK;
-void mbuf_resize(struct mbuf *a, size_t new_size) {
-  if (new_size > a->size || (new_size < a->size && new_size >= a->len)) {
-    char *buf = (char *) MBUF_REALLOC(a->buf, new_size);
-    /*
-     * In case realloc fails, there's not much we can do, except keep things as
-     * they are. Note that NULL is a valid return value from realloc when
-     * size == 0, but that is covered too.
-     */
-    if (buf == NULL && new_size != 0) return;
-    a->buf = buf;
-    a->size = new_size;
-  }
-}
-
-void mbuf_trim(struct mbuf *mbuf) WEAK;
-void mbuf_trim(struct mbuf *mbuf) {
-  mbuf_resize(mbuf, mbuf->len);
-}
-
-size_t mbuf_insert(struct mbuf *a, size_t off, const void *buf, size_t) WEAK;
-size_t mbuf_insert(struct mbuf *a, size_t off, const void *buf, size_t len) {
-  char *p = NULL;
-
-  assert(a != NULL);
-  assert(a->len <= a->size);
-  assert(off <= a->len);
-
-  /* check overflow */
-  if (~(size_t) 0 - (size_t) a->buf < len) return 0;
-
-  if (a->len + len <= a->size) {
-    memmove(a->buf + off + len, a->buf + off, a->len - off);
-    if (buf != NULL) {
-      memcpy(a->buf + off, buf, len);
-    }
-    a->len += len;
-  } else {
-    size_t min_size = (a->len + len);
-    size_t new_size = (size_t)(min_size * MBUF_SIZE_MULTIPLIER);
-    if (new_size - min_size > MBUF_SIZE_MAX_HEADROOM) {
-      new_size = min_size + MBUF_SIZE_MAX_HEADROOM;
-    }
-    p = (char *) MBUF_REALLOC(a->buf, new_size);
-    if (p == NULL && new_size != min_size) {
-      new_size = min_size;
-      p = (char *) MBUF_REALLOC(a->buf, new_size);
-    }
-    if (p != NULL) {
-      a->buf = p;
-      if (off != a->len) {
-        memmove(a->buf + off + len, a->buf + off, a->len - off);
-      }
-      if (buf != NULL) memcpy(a->buf + off, buf, len);
-      a->len += len;
-      a->size = new_size;
-    } else {
-      len = 0;
-    }
-  }
-
-  return len;
-}
-
-size_t mbuf_append(struct mbuf *a, const void *buf, size_t len) WEAK;
-size_t mbuf_append(struct mbuf *a, const void *buf, size_t len) {
-  return mbuf_insert(a, a->len, buf, len);
-}
-
-size_t mbuf_append_and_free(struct mbuf *a, void *buf, size_t len) WEAK;
-size_t mbuf_append_and_free(struct mbuf *a, void *data, size_t len) {
-  size_t ret;
-  /* Optimization: if the buffer is currently empty,
-   * take over the user-provided buffer. */
-  if (a->len == 0) {
-    if (a->buf != NULL) free(a->buf);
-    a->buf = (char *) data;
-    a->len = a->size = len;
-    return len;
-  }
-  ret = mbuf_insert(a, a->len, data, len);
-  free(data);
-  return ret;
-}
-
-void mbuf_remove(struct mbuf *mb, size_t n) WEAK;
-void mbuf_remove(struct mbuf *mb, size_t n) {
-  if (n > 0 && n <= mb->len) {
-    memmove(mb->buf, mb->buf + n, mb->len - n);
-    mb->len -= n;
-  }
-}
-
-void mbuf_clear(struct mbuf *mb) WEAK;
-void mbuf_clear(struct mbuf *mb) {
-  mb->len = 0;
-}
-
-void mbuf_move(struct mbuf *from, struct mbuf *to) WEAK;
-void mbuf_move(struct mbuf *from, struct mbuf *to) {
-  memcpy(to, from, sizeof(*to));
-  memset(from, 0, sizeof(*from));
-}
-
-#endif /* EXCLUDE_COMMON */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/mg_str.c"
-#endif
-
-/* Amalgamated: #include "common/mg_mem.h" */
-/* Amalgamated: #include "common/mg_str.h" */
-/* Amalgamated: #include "common/platform.h" */
-
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
-
-int mg_ncasecmp(const char *s1, const char *s2, size_t len) WEAK;
-
-struct mg_str mg_mk_str(const char *s) WEAK;
-struct mg_str mg_mk_str(const char *s) {
-  struct mg_str ret = {s, 0};
-  if (s != NULL) ret.len = strlen(s);
-  return ret;
-}
-
-struct mg_str mg_mk_str_n(const char *s, size_t len) WEAK;
-struct mg_str mg_mk_str_n(const char *s, size_t len) {
-  struct mg_str ret = {s, len};
-  return ret;
-}
-
-int mg_vcmp(const struct mg_str *str1, const char *str2) WEAK;
-int mg_vcmp(const struct mg_str *str1, const char *str2) {
-  size_t n2 = strlen(str2), n1 = str1->len;
-  int r = strncmp(str1->p, str2, (n1 < n2) ? n1 : n2);
-  if (r == 0) {
-    return n1 - n2;
-  }
-  return r;
-}
-
-int mg_vcasecmp(const struct mg_str *str1, const char *str2) WEAK;
-int mg_vcasecmp(const struct mg_str *str1, const char *str2) {
-  size_t n2 = strlen(str2), n1 = str1->len;
-  int r = mg_ncasecmp(str1->p, str2, (n1 < n2) ? n1 : n2);
-  if (r == 0) {
-    return n1 - n2;
-  }
-  return r;
-}
-
-static struct mg_str mg_strdup_common(const struct mg_str s,
-                                      int nul_terminate) {
-  struct mg_str r = {NULL, 0};
-  if (s.len > 0 && s.p != NULL) {
-    char *sc = (char *) MG_MALLOC(s.len + (nul_terminate ? 1 : 0));
-    if (sc != NULL) {
-      memcpy(sc, s.p, s.len);
-      if (nul_terminate) sc[s.len] = '\0';
-      r.p = sc;
-      r.len = s.len;
-    }
-  }
-  return r;
-}
-
-struct mg_str mg_strdup(const struct mg_str s) WEAK;
-struct mg_str mg_strdup(const struct mg_str s) {
-  return mg_strdup_common(s, 0 /* NUL-terminate */);
-}
-
-struct mg_str mg_strdup_nul(const struct mg_str s) WEAK;
-struct mg_str mg_strdup_nul(const struct mg_str s) {
-  return mg_strdup_common(s, 1 /* NUL-terminate */);
-}
-
-const char *mg_strchr(const struct mg_str s, int c) WEAK;
-const char *mg_strchr(const struct mg_str s, int c) {
-  size_t i;
-  for (i = 0; i < s.len; i++) {
-    if (s.p[i] == c) return &s.p[i];
-  }
-  return NULL;
-}
-
-int mg_strcmp(const struct mg_str str1, const struct mg_str str2) WEAK;
-int mg_strcmp(const struct mg_str str1, const struct mg_str str2) {
-  size_t i = 0;
-  while (i < str1.len && i < str2.len) {
-    int c1 = str1.p[i];
-    int c2 = str2.p[i];
-    if (c1 < c2) return -1;
-    if (c1 > c2) return 1;
-    i++;
-  }
-  if (i < str1.len) return 1;
-  if (i < str2.len) return -1;
-  return 0;
-}
-
-int mg_strncmp(const struct mg_str, const struct mg_str, size_t n) WEAK;
-int mg_strncmp(const struct mg_str str1, const struct mg_str str2, size_t n) {
-  struct mg_str s1 = str1;
-  struct mg_str s2 = str2;
-
-  if (s1.len > n) {
-    s1.len = n;
-  }
-  if (s2.len > n) {
-    s2.len = n;
-  }
-  return mg_strcmp(s1, s2);
-}
-
-int mg_strcasecmp(const struct mg_str str1, const struct mg_str str2) WEAK;
-int mg_strcasecmp(const struct mg_str str1, const struct mg_str str2) {
-  size_t i = 0;
-  while (i < str1.len && i < str2.len) {
-    int c1 = tolower((int) str1.p[i]);
-    int c2 = tolower((int) str2.p[i]);
-    if (c1 < c2) return -1;
-    if (c1 > c2) return 1;
-    i++;
-  }
-  if (i < str1.len) return 1;
-  if (i < str2.len) return -1;
-  return 0;
-}
-
-void mg_strfree(struct mg_str *s) WEAK;
-void mg_strfree(struct mg_str *s) {
-  char *sp = (char *) s->p;
-  s->p = NULL;
-  s->len = 0;
-  if (sp != NULL) free(sp);
-}
-
-const char *mg_strstr(const struct mg_str haystack,
-                      const struct mg_str needle) WEAK;
-const char *mg_strstr(const struct mg_str haystack,
-                      const struct mg_str needle) {
-  size_t i;
-  if (needle.len > haystack.len) return NULL;
-  for (i = 0; i <= haystack.len - needle.len; i++) {
-    if (memcmp(haystack.p + i, needle.p, needle.len) == 0) {
-      return haystack.p + i;
-    }
-  }
-  return NULL;
-}
-
-struct mg_str mg_strstrip(struct mg_str s) WEAK;
-struct mg_str mg_strstrip(struct mg_str s) {
-  while (s.len > 0 && isspace((int) *s.p)) {
-    s.p++;
-    s.len--;
-  }
-  while (s.len > 0 && isspace((int) *(s.p + s.len - 1))) {
-    s.len--;
-  }
-  return s;
-}
-
-int mg_str_starts_with(struct mg_str s, struct mg_str prefix) WEAK;
-int mg_str_starts_with(struct mg_str s, struct mg_str prefix) {
-  const struct mg_str sp = MG_MK_STR_N(s.p, prefix.len);
-  if (s.len < prefix.len) return 0;
-  return (mg_strcmp(sp, prefix) == 0);
-}
-#ifdef MJS_MODULE_LINES
-#line 1 "src/common/str_util.c"
-#endif
-
-#ifndef EXCLUDE_COMMON
-
-/* Amalgamated: #include "common/str_util.h" */
-/* Amalgamated: #include "common/mg_mem.h" */
-/* Amalgamated: #include "common/platform.h" */
-
-#ifndef C_DISABLE_BUILTIN_SNPRINTF
-#define C_DISABLE_BUILTIN_SNPRINTF 0
-#endif
-
-/* Amalgamated: #include "common/mg_mem.h" */
-
-size_t c_strnlen(const char *s, size_t maxlen) WEAK;
-size_t c_strnlen(const char *s, size_t maxlen) {
-  size_t l = 0;
-  for (; l < maxlen && s[l] != '\0'; l++) {
-  }
-  return l;
-}
-
-#define C_SNPRINTF_APPEND_CHAR(ch)       \
-  do {                                   \
-    if (i < (int) buf_size) buf[i] = ch; \
-    i++;                                 \
-  } while (0)
-
-#define C_SNPRINTF_FLAG_ZERO 1
-
-#if C_DISABLE_BUILTIN_SNPRINTF
-int c_vsnprintf(char *buf, size_t buf_size, const char *fmt, va_list ap) WEAK;
-int c_vsnprintf(char *buf, size_t buf_size, const char *fmt, va_list ap) {
-  return vsnprintf(buf, buf_size, fmt, ap);
-}
-#else
-static int c_itoa(char *buf, size_t buf_size, int64_t num, int base, int flags,
-                  int field_width) {
-  char tmp[40];
-  int i = 0, k = 0, neg = 0;
-
-  if (num < 0) {
-    neg++;
-    num = -num;
-  }
-
-  /* Print into temporary buffer - in reverse order */
-  do {
-    int rem = num % base;
-    if (rem < 10) {
-      tmp[k++] = '0' + rem;
-    } else {
-      tmp[k++] = 'a' + (rem - 10);
-    }
-    num /= base;
-  } while (num > 0);
-
-  /* Zero padding */
-  if (flags && C_SNPRINTF_FLAG_ZERO) {
-    while (k < field_width && k < (int) sizeof(tmp) - 1) {
-      tmp[k++] = '0';
-    }
-  }
-
-  /* And sign */
-  if (neg) {
-    tmp[k++] = '-';
-  }
-
-  /* Now output */
-  while (--k >= 0) {
-    C_SNPRINTF_APPEND_CHAR(tmp[k]);
-  }
-
-  return i;
-}
-
-int c_vsnprintf(char *buf, size_t buf_size, const char *fmt, va_list ap) WEAK;
-int c_vsnprintf(char *buf, size_t buf_size, const char *fmt, va_list ap) {
-  int ch, i = 0, len_mod, flags, precision, field_width;
-
-  while ((ch = *fmt++) != '\0') {
-    if (ch != '%') {
-      C_SNPRINTF_APPEND_CHAR(ch);
-    } else {
-      /*
-       * Conversion specification:
-       *   zero or more flags (one of: # 0 - <space> + ')
-       *   an optional minimum  field  width (digits)
-       *   an  optional precision (. followed by digits, or *)
-       *   an optional length modifier (one of: hh h l ll L q j z t)
-       *   conversion specifier (one of: d i o u x X e E f F g G a A c s p n)
-       */
-      flags = field_width = precision = len_mod = 0;
-
-      /* Flags. only zero-pad flag is supported. */
-      if (*fmt == '0') {
-        flags |= C_SNPRINTF_FLAG_ZERO;
-      }
-
-      /* Field width */
-      while (*fmt >= '0' && *fmt <= '9') {
-        field_width *= 10;
-        field_width += *fmt++ - '0';
-      }
-      /* Dynamic field width */
-      if (*fmt == '*') {
-        field_width = va_arg(ap, int);
-        fmt++;
-      }
-
-      /* Precision */
-      if (*fmt == '.') {
-        fmt++;
-        if (*fmt == '*') {
-          precision = va_arg(ap, int);
-          fmt++;
-        } else {
-          while (*fmt >= '0' && *fmt <= '9') {
-            precision *= 10;
-            precision += *fmt++ - '0';
-          }
-        }
-      }
-
-      /* Length modifier */
-      switch (*fmt) {
-        case 'h':
-        case 'l':
-        case 'L':
-        case 'I':
-        case 'q':
-        case 'j':
-        case 'z':
-        case 't':
-          len_mod = *fmt++;
-          if (*fmt == 'h') {
-            len_mod = 'H';
-            fmt++;
-          }
-          if (*fmt == 'l') {
-            len_mod = 'q';
-            fmt++;
-          }
-          break;
-      }
-
-      ch = *fmt++;
-      if (ch == 's') {
-        const char *s = va_arg(ap, const char *); /* Always fetch parameter */
-        int j;
-        int pad = field_width - (precision >= 0 ? c_strnlen(s, precision) : 0);
-        for (j = 0; j < pad; j++) {
-          C_SNPRINTF_APPEND_CHAR(' ');
-        }
-
-        /* `s` may be NULL in case of %.*s */
-        if (s != NULL) {
-          /* Ignore negative and 0 precisions */
-          for (j = 0; (precision <= 0 || j < precision) && s[j] != '\0'; j++) {
-            C_SNPRINTF_APPEND_CHAR(s[j]);
-          }
-        }
-      } else if (ch == 'c') {
-        ch = va_arg(ap, int); /* Always fetch parameter */
-        C_SNPRINTF_APPEND_CHAR(ch);
-      } else if (ch == 'd' && len_mod == 0) {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, int), 10, flags,
-                    field_width);
-      } else if (ch == 'd' && len_mod == 'l') {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, long), 10, flags,
-                    field_width);
-#ifdef SSIZE_MAX
-      } else if (ch == 'd' && len_mod == 'z') {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, ssize_t), 10, flags,
-                    field_width);
-#endif
-      } else if (ch == 'd' && len_mod == 'q') {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, int64_t), 10, flags,
-                    field_width);
-      } else if ((ch == 'x' || ch == 'u') && len_mod == 0) {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, unsigned),
-                    ch == 'x' ? 16 : 10, flags, field_width);
-      } else if ((ch == 'x' || ch == 'u') && len_mod == 'l') {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, unsigned long),
-                    ch == 'x' ? 16 : 10, flags, field_width);
-      } else if ((ch == 'x' || ch == 'u') && len_mod == 'z') {
-        i += c_itoa(buf + i, buf_size - i, va_arg(ap, size_t),
-                    ch == 'x' ? 16 : 10, flags, field_width);
-      } else if (ch == 'p') {
-        unsigned long num = (unsigned long) (uintptr_t) va_arg(ap, void *);
-        C_SNPRINTF_APPEND_CHAR('0');
-        C_SNPRINTF_APPEND_CHAR('x');
-        i += c_itoa(buf + i, buf_size - i, num, 16, flags, 0);
-      } else {
-#ifndef NO_LIBC
-        /*
-         * TODO(lsm): abort is not nice in a library, remove it
-         * Also, ESP8266 SDK doesn't have it
-         */
-        abort();
-#endif
-      }
-    }
-  }
-
-  /* Zero-terminate the result */
-  if (buf_size > 0) {
-    buf[i < (int) buf_size ? i : (int) buf_size - 1] = '\0';
-  }
-
-  return i;
-}
-#endif
-
-int c_snprintf(char *buf, size_t buf_size, const char *fmt, ...) WEAK;
-int c_snprintf(char *buf, size_t buf_size, const char *fmt, ...) {
-  int result;
-  va_list ap;
-  va_start(ap, fmt);
-  result = c_vsnprintf(buf, buf_size, fmt, ap);
-  va_end(ap);
-  return result;
-}
-
-#ifdef _WIN32
-int to_wchar(const char *path, wchar_t *wbuf, size_t wbuf_len) {
-  int ret;
-  char buf[MAX_PATH * 2], buf2[MAX_PATH * 2], *p;
-
-  strncpy(buf, path, sizeof(buf));
-  buf[sizeof(buf) - 1] = '\0';
-
-  /* Trim trailing slashes. Leave backslash for paths like "X:\" */
-  p = buf + strlen(buf) - 1;
-  while (p > buf && p[-1] != ':' && (p[0] == '\\' || p[0] == '/')) *p-- = '\0';
-
-  memset(wbuf, 0, wbuf_len * sizeof(wchar_t));
-  ret = MultiByteToWideChar(CP_UTF8, 0, buf, -1, wbuf, (int) wbuf_len);
-
-  /*
-   * Convert back to Unicode. If doubly-converted string does not match the
-   * original, something is fishy, reject.
-   */
-  WideCharToMultiByte(CP_UTF8, 0, wbuf, (int) wbuf_len, buf2, sizeof(buf2),
-                      NULL, NULL);
-  if (strcmp(buf, buf2) != 0) {
-    wbuf[0] = L'\0';
-    ret = 0;
-  }
-
-  return ret;
-}
-#endif /* _WIN32 */
-
-/* The simplest O(mn) algorithm. Better implementation are GPLed */
-const char *c_strnstr(const char *s, const char *find, size_t slen) WEAK;
-const char *c_strnstr(const char *s, const char *find, size_t slen) {
-  size_t find_length = strlen(find);
-  size_t i;
-
-  for (i = 0; i < slen; i++) {
-    if (i + find_length > slen) {
-      return NULL;
-    }
-
-    if (strncmp(&s[i], find, find_length) == 0) {
-      return &s[i];
-    }
-  }
-
-  return NULL;
-}
-
-#if CS_ENABLE_STRDUP
-char *strdup(const char *src) WEAK;
-char *strdup(const char *src) {
-  size_t len = strlen(src) + 1;
-  char *ret = MG_MALLOC(len);
-  if (ret != NULL) {
-    strcpy(ret, src);
-  }
-  return ret;
-}
-#endif
-
-void cs_to_hex(char *to, const unsigned char *p, size_t len) WEAK;
-void cs_to_hex(char *to, const unsigned char *p, size_t len) {
-  static const char *hex = "0123456789abcdef";
-
-  for (; len--; p++) {
-    *to++ = hex[p[0] >> 4];
-    *to++ = hex[p[0] & 0x0f];
-  }
-  *to = '\0';
-}
-
-static int fourbit(int ch) {
-  if (ch >= '0' && ch <= '9') {
-    return ch - '0';
-  } else if (ch >= 'a' && ch <= 'f') {
-    return ch - 'a' + 10;
-  } else if (ch >= 'A' && ch <= 'F') {
-    return ch - 'A' + 10;
-  }
-  return 0;
-}
-
-void cs_from_hex(char *to, const char *p, size_t len) WEAK;
-void cs_from_hex(char *to, const char *p, size_t len) {
-  size_t i;
-
-  for (i = 0; i < len; i += 2) {
-    *to++ = (fourbit(p[i]) << 4) + fourbit(p[i + 1]);
-  }
-  *to = '\0';
-}
-
-#if CS_ENABLE_TO64
-int64_t cs_to64(const char *s) WEAK;
-int64_t cs_to64(const char *s) {
-  int64_t result = 0;
-  int64_t neg = 1;
-  while (*s && isspace((unsigned char) *s)) s++;
-  if (*s == '-') {
-    neg = -1;
-    s++;
-  }
-  while (isdigit((unsigned char) *s)) {
-    result *= 10;
-    result += (*s - '0');
-    s++;
-  }
-  return result * neg;
-}
-#endif
-
-static int str_util_lowercase(const char *s) {
-  return tolower(*(const unsigned char *) s);
-}
-
-int mg_ncasecmp(const char *s1, const char *s2, size_t len) WEAK;
-int mg_ncasecmp(const char *s1, const char *s2, size_t len) {
-  int diff = 0;
-
-  if (len > 0) do {
-      diff = str_util_lowercase(s1++) - str_util_lowercase(s2++);
-    } while (diff == 0 && s1[-1] != '\0' && --len > 0);
-
-  return diff;
-}
-
-int mg_casecmp(const char *s1, const char *s2) WEAK;
-int mg_casecmp(const char *s1, const char *s2) {
-  return mg_ncasecmp(s1, s2, (size_t) ~0);
-}
-
-int mg_asprintf(char **buf, size_t size, const char *fmt, ...) WEAK;
-int mg_asprintf(char **buf, size_t size, const char *fmt, ...) {
-  int ret;
-  va_list ap;
-  va_start(ap, fmt);
-  ret = mg_avprintf(buf, size, fmt, ap);
-  va_end(ap);
-  return ret;
-}
-
-int mg_avprintf(char **buf, size_t size, const char *fmt, va_list ap) WEAK;
-int mg_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
-  va_list ap_copy;
-  int len;
-
-  va_copy(ap_copy, ap);
-  len = vsnprintf(*buf, size, fmt, ap_copy);
-  va_end(ap_copy);
-
-  if (len < 0) {
-    /* eCos and Windows are not standard-compliant and return -1 when
-     * the buffer is too small. Keep allocating larger buffers until we
-     * succeed or out of memory. */
-    *buf = NULL; /* LCOV_EXCL_START */
-    while (len < 0) {
-      MG_FREE(*buf);
-      if (size == 0) {
-        size = 5;
-      }
-      size *= 2;
-      if ((*buf = (char *) MG_MALLOC(size)) == NULL) {
-        len = -1;
-        break;
-      }
-      va_copy(ap_copy, ap);
-      len = vsnprintf(*buf, size - 1, fmt, ap_copy);
-      va_end(ap_copy);
-    }
-
-    /*
-     * Microsoft version of vsnprintf() is not always null-terminated, so put
-     * the terminator manually
-     */
-    (*buf)[len] = 0;
-    /* LCOV_EXCL_STOP */
-  } else if (len >= (int) size) {
-    /* Standard-compliant code path. Allocate a buffer that is large enough. */
-    if ((*buf = (char *) MG_MALLOC(len + 1)) == NULL) {
-      len = -1; /* LCOV_EXCL_LINE */
-    } else {    /* LCOV_EXCL_LINE */
-      va_copy(ap_copy, ap);
-      len = vsnprintf(*buf, len + 1, fmt, ap_copy);
-      va_end(ap_copy);
-    }
-  }
-
-  return len;
-}
-
-const char *mg_next_comma_list_entry(const char *, struct mg_str *,
-                                     struct mg_str *) WEAK;
-const char *mg_next_comma_list_entry(const char *list, struct mg_str *val,
-                                     struct mg_str *eq_val) {
-  struct mg_str ret = mg_next_comma_list_entry_n(mg_mk_str(list), val, eq_val);
-  return ret.p;
-}
-
-struct mg_str mg_next_comma_list_entry_n(struct mg_str list, struct mg_str *val,
-                                         struct mg_str *eq_val) WEAK;
-struct mg_str mg_next_comma_list_entry_n(struct mg_str list, struct mg_str *val,
-                                         struct mg_str *eq_val) {
-  if (list.len == 0) {
-    /* End of the list */
-    list = mg_mk_str(NULL);
-  } else {
-    const char *chr = NULL;
-    *val = list;
-
-    if ((chr = mg_strchr(*val, ',')) != NULL) {
-      /* Comma found. Store length and shift the list ptr */
-      val->len = chr - val->p;
-      chr++;
-      list.len -= (chr - list.p);
-      list.p = chr;
-    } else {
-      /* This value is the last one */
-      list = mg_mk_str_n(list.p + list.len, 0);
-    }
-
-    if (eq_val != NULL) {
-      /* Value has form "x=y", adjust pointers and lengths */
-      /* so that val points to "x", and eq_val points to "y". */
-      eq_val->len = 0;
-      eq_val->p = (const char *) memchr(val->p, '=', val->len);
-      if (eq_val->p != NULL) {
-        eq_val->p++; /* Skip over '=' character */
-        eq_val->len = val->p + val->len - eq_val->p;
-        val->len = (eq_val->p - val->p) - 1;
-      }
-    }
-  }
-
-  return list;
-}
-
-size_t mg_match_prefix_n(const struct mg_str, const struct mg_str) WEAK;
-size_t mg_match_prefix_n(const struct mg_str pattern, const struct mg_str str) {
-  const char *or_str;
-  size_t res = 0, len = 0, i = 0, j = 0;
-
-  if ((or_str = (const char *) memchr(pattern.p, '|', pattern.len)) != NULL ||
-      (or_str = (const char *) memchr(pattern.p, ',', pattern.len)) != NULL) {
-    struct mg_str pstr = {pattern.p, (size_t)(or_str - pattern.p)};
-    res = mg_match_prefix_n(pstr, str);
-    if (res > 0) return res;
-    pstr.p = or_str + 1;
-    pstr.len = (pattern.p + pattern.len) - (or_str + 1);
-    return mg_match_prefix_n(pstr, str);
-  }
-
-  for (; i < pattern.len && j < str.len; i++, j++) {
-    if (pattern.p[i] == '?') {
-      continue;
-    } else if (pattern.p[i] == '*') {
-      i++;
-      if (i < pattern.len && pattern.p[i] == '*') {
-        i++;
-        len = str.len - j;
-      } else {
-        len = 0;
-        while (j + len < str.len && str.p[j + len] != '/') len++;
-      }
-      if (i == pattern.len || (pattern.p[i] == '$' && i == pattern.len - 1))
-        return j + len;
-      do {
-        const struct mg_str pstr = {pattern.p + i, pattern.len - i};
-        const struct mg_str sstr = {str.p + j + len, str.len - j - len};
-        res = mg_match_prefix_n(pstr, sstr);
-      } while (res == 0 && len != 0 && len-- > 0);
-      return res == 0 ? 0 : j + res + len;
-    } else if (str_util_lowercase(&pattern.p[i]) !=
-               str_util_lowercase(&str.p[j])) {
-      break;
-    }
-  }
-  if (i < pattern.len && pattern.p[i] == '$') {
-    return j == str.len ? str.len : 0;
-  }
-  return i == pattern.len ? j : 0;
-}
-
-size_t mg_match_prefix(const char *, int, const char *) WEAK;
-size_t mg_match_prefix(const char *pattern, int pattern_len, const char *str) {
-  const struct mg_str pstr = {pattern, (size_t) pattern_len};
-  struct mg_str s = {str, 0};
-  if (str != NULL) s.len = strlen(str);
-  return mg_match_prefix_n(pstr, s);
-}
-
-#endif /* EXCLUDE_COMMON */
-#ifdef MJS_MODULE_LINES
-#line 1 "src/frozen/frozen.c"
-#endif
-
-#define _CRT_SECURE_NO_WARNINGS /* Disable deprecation warning in VS2005+ */
-
-/* Amalgamated: #include "frozen.h" */
-
-#include <ctype.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#if !defined(WEAK)
-#if (defined(__GNUC__) || defined(__TI_COMPILER_VERSION__)) && !defined(_WIN32)
-#define WEAK __attribute__((weak))
-#else
-#define WEAK
-#endif
-#endif
-
-#ifdef _WIN32
-#undef snprintf
-#undef vsnprintf
-#define snprintf cs_win_snprintf
-#define vsnprintf cs_win_vsnprintf
-int cs_win_snprintf(char *str, size_t size, const char *format, ...);
-int cs_win_vsnprintf(char *str, size_t size, const char *format, va_list ap);
-#if _MSC_VER >= 1700
-#include <stdint.h>
-#else
-typedef _int64 int64_t;
-typedef unsigned _int64 uint64_t;
-#endif
-#define PRId64 "I64d"
-#define PRIu64 "I64u"
-#else /* _WIN32 */
-/* <inttypes.h> wants this for C++ */
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-#include <inttypes.h>
-#endif /* _WIN32 */
-
-#ifndef INT64_FMT
-#define INT64_FMT PRId64
-#endif
-#ifndef UINT64_FMT
-#define UINT64_FMT PRIu64
-#endif
-
-#ifndef va_copy
-#define va_copy(x, y) x = y
-#endif
-
-#ifndef JSON_ENABLE_ARRAY
-#define JSON_ENABLE_ARRAY 1
-#endif
-
-struct frozen {
-  const char *end;
-  const char *cur;
-
-  const char *cur_name;
-  size_t cur_name_len;
-
-  /* For callback API */
-  char path[JSON_MAX_PATH_LEN];
-  size_t path_len;
-  void *callback_data;
-  json_walk_callback_t callback;
-};
-
-struct fstate {
-  const char *ptr;
-  size_t path_len;
-};
-
-#define SET_STATE(fr, ptr, str, len)              \
-  struct fstate fstate = {(ptr), (fr)->path_len}; \
-  json_append_to_path((fr), (str), (len));
-
-#define CALL_BACK(fr, tok, value, len)                                        \
-  do {                                                                        \
-    if ((fr)->callback &&                                                     \
-        ((fr)->path_len == 0 || (fr)->path[(fr)->path_len - 1] != '.')) {     \
-      struct json_token t = {(value), (int) (len), (tok)};                    \
-                                                                              \
-      /* Call the callback with the given value and current name */           \
-      (fr)->callback((fr)->callback_data, (fr)->cur_name, (fr)->cur_name_len, \
-                     (fr)->path, &t);                                         \
-                                                                              \
-      /* Reset the name */                                                    \
-      (fr)->cur_name = NULL;                                                  \
-      (fr)->cur_name_len = 0;                                                 \
-    }                                                                         \
-  } while (0)
-
-static int json_append_to_path(struct frozen *f, const char *str, int size) {
-  int n = f->path_len;
-  int left = sizeof(f->path) - n - 1;
-  if (size > left) size = left;
-  memcpy(f->path + n, str, size);
-  f->path[n + size] = '\0';
-  f->path_len += size;
-  return n;
-}
-
-static void json_truncate_path(struct frozen *f, size_t len) {
-  f->path_len = len;
-  f->path[len] = '\0';
-}
-
-static int json_parse_object(struct frozen *f);
-static int json_parse_value(struct frozen *f);
-
-#define EXPECT(cond, err_code)      \
-  do {                              \
-    if (!(cond)) return (err_code); \
-  } while (0)
-
-#define TRY(expr)          \
-  do {                     \
-    int _n = expr;         \
-    if (_n < 0) return _n; \
-  } while (0)
-
-#define END_OF_STRING (-1)
-
-static int json_left(const struct frozen *f) {
-  return f->end - f->cur;
-}
-
-static int json_isspace(int ch) {
-  return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n';
-}
-
-static void json_skip_whitespaces(struct frozen *f) {
-  while (f->cur < f->end && json_isspace(*f->cur)) f->cur++;
-}
-
-static int json_cur(struct frozen *f) {
-  json_skip_whitespaces(f);
-  return f->cur >= f->end ? END_OF_STRING : *(unsigned char *) f->cur;
-}
-
-static int json_test_and_skip(struct frozen *f, int expected) {
-  int ch = json_cur(f);
-  if (ch == expected) {
-    f->cur++;
-    return 0;
-  }
-  return ch == END_OF_STRING ? JSON_STRING_INCOMPLETE : JSON_STRING_INVALID;
-}
-
-static int json_isalpha(int ch) {
-  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
-}
-
-static int json_isdigit(int ch) {
-  return ch >= '0' && ch <= '9';
-}
-
-static int json_isxdigit(int ch) {
-  return json_isdigit(ch) || (ch >= 'a' && ch <= 'f') ||
-         (ch >= 'A' && ch <= 'F');
-}
-
-static int json_get_escape_len(const char *s, int len) {
-  switch (*s) {
-    case 'u':
-      return len < 6 ? JSON_STRING_INCOMPLETE
-                     : json_isxdigit(s[1]) && json_isxdigit(s[2]) &&
-                               json_isxdigit(s[3]) && json_isxdigit(s[4])
-                           ? 5
-                           : JSON_STRING_INVALID;
-    case '"':
-    case '\\':
-    case '/':
-    case 'b':
-    case 'f':
-    case 'n':
-    case 'r':
-    case 't':
-      return len < 2 ? JSON_STRING_INCOMPLETE : 1;
-    default:
-      return JSON_STRING_INVALID;
-  }
-}
-
-/* identifier = letter { letter | digit | '_' } */
-static int json_parse_identifier(struct frozen *f) {
-  EXPECT(json_isalpha(json_cur(f)), JSON_STRING_INVALID);
-  {
-    SET_STATE(f, f->cur, "", 0);
-    while (f->cur < f->end &&
-           (*f->cur == '_' || json_isalpha(*f->cur) || json_isdigit(*f->cur))) {
-      f->cur++;
-    }
-    json_truncate_path(f, fstate.path_len);
-    CALL_BACK(f, JSON_TYPE_STRING, fstate.ptr, f->cur - fstate.ptr);
-  }
-  return 0;
-}
-
-static int json_get_utf8_char_len(unsigned char ch) {
-  if ((ch & 0x80) == 0) return 1;
-  switch (ch & 0xf0) {
-    case 0xf0:
-      return 4;
-    case 0xe0:
-      return 3;
-    default:
-      return 2;
-  }
-}
-
-/* string = '"' { quoted_printable_chars } '"' */
-static int json_parse_string(struct frozen *f) {
-  int n, ch = 0, len = 0;
-  TRY(json_test_and_skip(f, '"'));
-  {
-    SET_STATE(f, f->cur, "", 0);
-    for (; f->cur < f->end; f->cur += len) {
-      ch = *(unsigned char *) f->cur;
-      len = json_get_utf8_char_len((unsigned char) ch);
-      EXPECT(ch >= 32 && len > 0, JSON_STRING_INVALID); /* No control chars */
-      EXPECT(len <= json_left(f), JSON_STRING_INCOMPLETE);
-      if (ch == '\\') {
-        EXPECT((n = json_get_escape_len(f->cur + 1, json_left(f))) > 0, n);
-        len += n;
-      } else if (ch == '"') {
-        json_truncate_path(f, fstate.path_len);
-        CALL_BACK(f, JSON_TYPE_STRING, fstate.ptr, f->cur - fstate.ptr);
-        f->cur++;
-        break;
-      };
-    }
-  }
-  return ch == '"' ? 0 : JSON_STRING_INCOMPLETE;
-}
-
-/* number = [ '-' ] digit+ [ '.' digit+ ] [ ['e'|'E'] ['+'|'-'] digit+ ] */
-static int json_parse_number(struct frozen *f) {
-  int ch = json_cur(f);
-  SET_STATE(f, f->cur, "", 0);
-  if (ch == '-') f->cur++;
-  EXPECT(f->cur < f->end, JSON_STRING_INCOMPLETE);
-  if (f->cur + 1 < f->end && f->cur[0] == '0' && f->cur[1] == 'x') {
-    f->cur += 2;
-    EXPECT(f->cur < f->end, JSON_STRING_INCOMPLETE);
-    EXPECT(json_isxdigit(f->cur[0]), JSON_STRING_INVALID);
-    while (f->cur < f->end && json_isxdigit(f->cur[0])) f->cur++;
-  } else {
-    EXPECT(json_isdigit(f->cur[0]), JSON_STRING_INVALID);
-    while (f->cur < f->end && json_isdigit(f->cur[0])) f->cur++;
-    if (f->cur < f->end && f->cur[0] == '.') {
-      f->cur++;
-      EXPECT(f->cur < f->end, JSON_STRING_INCOMPLETE);
-      EXPECT(json_isdigit(f->cur[0]), JSON_STRING_INVALID);
-      while (f->cur < f->end && json_isdigit(f->cur[0])) f->cur++;
-    }
-    if (f->cur < f->end && (f->cur[0] == 'e' || f->cur[0] == 'E')) {
-      f->cur++;
-      EXPECT(f->cur < f->end, JSON_STRING_INCOMPLETE);
-      if ((f->cur[0] == '+' || f->cur[0] == '-')) f->cur++;
-      EXPECT(f->cur < f->end, JSON_STRING_INCOMPLETE);
-      EXPECT(json_isdigit(f->cur[0]), JSON_STRING_INVALID);
-      while (f->cur < f->end && json_isdigit(f->cur[0])) f->cur++;
-    }
-  }
-  json_truncate_path(f, fstate.path_len);
-  CALL_BACK(f, JSON_TYPE_NUMBER, fstate.ptr, f->cur - fstate.ptr);
-  return 0;
-}
-
-#if JSON_ENABLE_ARRAY
-/* array = '[' [ value { ',' value } ] ']' */
-static int json_parse_array(struct frozen *f) {
-  int i = 0, current_path_len;
-  char buf[20];
-  CALL_BACK(f, JSON_TYPE_ARRAY_START, NULL, 0);
-  TRY(json_test_and_skip(f, '['));
-  {
-    {
-      SET_STATE(f, f->cur - 1, "", 0);
-      while (json_cur(f) != ']') {
-        snprintf(buf, sizeof(buf), "[%d]", i);
-        i++;
-        current_path_len = json_append_to_path(f, buf, strlen(buf));
-        f->cur_name =
-            f->path + strlen(f->path) - strlen(buf) + 1 /*opening brace*/;
-        f->cur_name_len = strlen(buf) - 2 /*braces*/;
-        TRY(json_parse_value(f));
-        json_truncate_path(f, current_path_len);
-        if (json_cur(f) == ',') f->cur++;
-      }
-      TRY(json_test_and_skip(f, ']'));
-      json_truncate_path(f, fstate.path_len);
-      CALL_BACK(f, JSON_TYPE_ARRAY_END, fstate.ptr, f->cur - fstate.ptr);
-    }
-  }
-  return 0;
-}
-#endif /* JSON_ENABLE_ARRAY */
-
-static int json_expect(struct frozen *f, const char *s, int len,
-                       enum json_token_type tok_type) {
-  int i, n = json_left(f);
-  SET_STATE(f, f->cur, "", 0);
-  for (i = 0; i < len; i++) {
-    if (i >= n) return JSON_STRING_INCOMPLETE;
-    if (f->cur[i] != s[i]) return JSON_STRING_INVALID;
-  }
-  f->cur += len;
-  json_truncate_path(f, fstate.path_len);
-
-  CALL_BACK(f, tok_type, fstate.ptr, f->cur - fstate.ptr);
-
-  return 0;
-}
-
-/* value = 'null' | 'true' | 'false' | number | string | array | object */
-static int json_parse_value(struct frozen *f) {
-  int ch = json_cur(f);
-
-  switch (ch) {
-    case '"':
-      TRY(json_parse_string(f));
-      break;
-    case '{':
-      TRY(json_parse_object(f));
-      break;
-#if JSON_ENABLE_ARRAY
-    case '[':
-      TRY(json_parse_array(f));
-      break;
-#endif
-    case 'n':
-      TRY(json_expect(f, "null", 4, JSON_TYPE_NULL));
-      break;
-    case 't':
-      TRY(json_expect(f, "true", 4, JSON_TYPE_TRUE));
-      break;
-    case 'f':
-      TRY(json_expect(f, "false", 5, JSON_TYPE_FALSE));
-      break;
-    case '-':
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-      TRY(json_parse_number(f));
-      break;
-    default:
-      return ch == END_OF_STRING ? JSON_STRING_INCOMPLETE : JSON_STRING_INVALID;
-  }
-
-  return 0;
-}
-
-/* key = identifier | string */
-static int json_parse_key(struct frozen *f) {
-  int ch = json_cur(f);
-  if (json_isalpha(ch)) {
-    TRY(json_parse_identifier(f));
-  } else if (ch == '"') {
-    TRY(json_parse_string(f));
-  } else {
-    return ch == END_OF_STRING ? JSON_STRING_INCOMPLETE : JSON_STRING_INVALID;
-  }
-  return 0;
-}
-
-/* pair = key ':' value */
-static int json_parse_pair(struct frozen *f) {
-  int current_path_len;
-  const char *tok;
-  json_skip_whitespaces(f);
-  tok = f->cur;
-  TRY(json_parse_key(f));
-  {
-    f->cur_name = *tok == '"' ? tok + 1 : tok;
-    f->cur_name_len = *tok == '"' ? f->cur - tok - 2 : f->cur - tok;
-    current_path_len = json_append_to_path(f, f->cur_name, f->cur_name_len);
-  }
-  TRY(json_test_and_skip(f, ':'));
-  TRY(json_parse_value(f));
-  json_truncate_path(f, current_path_len);
-  return 0;
-}
-
-/* object = '{' pair { ',' pair } '}' */
-static int json_parse_object(struct frozen *f) {
-  CALL_BACK(f, JSON_TYPE_OBJECT_START, NULL, 0);
-  TRY(json_test_and_skip(f, '{'));
-  {
-    SET_STATE(f, f->cur - 1, ".", 1);
-    while (json_cur(f) != '}') {
-      TRY(json_parse_pair(f));
-      if (json_cur(f) == ',') f->cur++;
-    }
-    TRY(json_test_and_skip(f, '}'));
-    json_truncate_path(f, fstate.path_len);
-    CALL_BACK(f, JSON_TYPE_OBJECT_END, fstate.ptr, f->cur - fstate.ptr);
-  }
-  return 0;
-}
-
-static int json_doit(struct frozen *f) {
-  if (f->cur == 0 || f->end < f->cur) return JSON_STRING_INVALID;
-  if (f->end == f->cur) return JSON_STRING_INCOMPLETE;
-  return json_parse_value(f);
-}
-
-int json_escape(struct json_out *out, const char *p, size_t len) WEAK;
-int json_escape(struct json_out *out, const char *p, size_t len) {
-  size_t i, cl, n = 0;
-  const char *hex_digits = "0123456789abcdef";
-  const char *specials = "btnvfr";
-
-  for (i = 0; i < len; i++) {
-    unsigned char ch = ((unsigned char *) p)[i];
-    if (ch == '"' || ch == '\\') {
-      n += out->printer(out, "\\", 1);
-      n += out->printer(out, p + i, 1);
-    } else if (ch >= '\b' && ch <= '\r') {
-      n += out->printer(out, "\\", 1);
-      n += out->printer(out, &specials[ch - '\b'], 1);
-    } else if (isprint(ch)) {
-      n += out->printer(out, p + i, 1);
-    } else if ((cl = json_get_utf8_char_len(ch)) == 1) {
-      n += out->printer(out, "\\u00", 4);
-      n += out->printer(out, &hex_digits[(ch >> 4) % 0xf], 1);
-      n += out->printer(out, &hex_digits[ch % 0xf], 1);
-    } else {
-      n += out->printer(out, p + i, cl);
-      i += cl - 1;
-    }
-  }
-
-  return n;
-}
-
-int json_printer_buf(struct json_out *out, const char *buf, size_t len) WEAK;
-int json_printer_buf(struct json_out *out, const char *buf, size_t len) {
-  size_t avail = out->u.buf.size - out->u.buf.len;
-  size_t n = len < avail ? len : avail;
-  memcpy(out->u.buf.buf + out->u.buf.len, buf, n);
-  out->u.buf.len += n;
-  if (out->u.buf.size > 0) {
-    size_t idx = out->u.buf.len;
-    if (idx >= out->u.buf.size) idx = out->u.buf.size - 1;
-    out->u.buf.buf[idx] = '\0';
-  }
-  return len;
-}
-
-int json_printer_file(struct json_out *out, const char *buf, size_t len) WEAK;
-int json_printer_file(struct json_out *out, const char *buf, size_t len) {
-  return fwrite(buf, 1, len, out->u.fp);
-}
-
-#if JSON_ENABLE_BASE64
-static int b64idx(int c) {
-  if (c < 26) {
-    return c + 'A';
-  } else if (c < 52) {
-    return c - 26 + 'a';
-  } else if (c < 62) {
-    return c - 52 + '0';
-  } else {
-    return c == 62 ? '+' : '/';
-  }
-}
-
-static int b64rev(int c) {
-  if (c >= 'A' && c <= 'Z') {
-    return c - 'A';
-  } else if (c >= 'a' && c <= 'z') {
-    return c + 26 - 'a';
-  } else if (c >= '0' && c <= '9') {
-    return c + 52 - '0';
-  } else if (c == '+') {
-    return 62;
-  } else if (c == '/') {
-    return 63;
-  } else {
-    return 64;
-  }
-}
-
-static int b64enc(struct json_out *out, const unsigned char *p, int n) {
-  char buf[4];
-  int i, len = 0;
-  for (i = 0; i < n; i += 3) {
-    int a = p[i], b = i + 1 < n ? p[i + 1] : 0, c = i + 2 < n ? p[i + 2] : 0;
-    buf[0] = b64idx(a >> 2);
-    buf[1] = b64idx((a & 3) << 4 | (b >> 4));
-    buf[2] = b64idx((b & 15) << 2 | (c >> 6));
-    buf[3] = b64idx(c & 63);
-    if (i + 1 >= n) buf[2] = '=';
-    if (i + 2 >= n) buf[3] = '=';
-    len += out->printer(out, buf, sizeof(buf));
-  }
-  return len;
-}
-
-static int b64dec(const char *src, int n, char *dst) {
-  const char *end = src + n;
-  int len = 0;
-  while (src + 3 < end) {
-    int a = b64rev(src[0]), b = b64rev(src[1]), c = b64rev(src[2]),
-        d = b64rev(src[3]);
-    dst[len++] = (a << 2) | (b >> 4);
-    if (src[2] != '=') {
-      dst[len++] = (b << 4) | (c >> 2);
-      if (src[3] != '=') {
-        dst[len++] = (c << 6) | d;
-      }
-    }
-    src += 4;
-  }
-  return len;
-}
-#endif /* JSON_ENABLE_BASE64 */
-
-static unsigned char hexdec(const char *s) {
-#define HEXTOI(x) (x >= '0' && x <= '9' ? x - '0' : x - 'W')
-  int a = tolower(*(const unsigned char *) s);
-  int b = tolower(*(const unsigned char *) (s + 1));
-  return (HEXTOI(a) << 4) | HEXTOI(b);
-}
-
-int json_vprintf(struct json_out *out, const char *fmt, va_list xap) WEAK;
-int json_vprintf(struct json_out *out, const char *fmt, va_list xap) {
-  int len = 0;
-  const char *quote = "\"", *null = "null";
-  va_list ap;
-  va_copy(ap, xap);
-
-  while (*fmt != '\0') {
-    if (strchr(":, \r\n\t[]{}\"", *fmt) != NULL) {
-      len += out->printer(out, fmt, 1);
-      fmt++;
-    } else if (fmt[0] == '%') {
-      char buf[21];
-      size_t skip = 2;
-
-      if (fmt[1] == 'l' && fmt[2] == 'l' && (fmt[3] == 'd' || fmt[3] == 'u')) {
-        int64_t val = va_arg(ap, int64_t);
-        const char *fmt2 = fmt[3] == 'u' ? "%" UINT64_FMT : "%" INT64_FMT;
-        snprintf(buf, sizeof(buf), fmt2, val);
-        len += out->printer(out, buf, strlen(buf));
-        skip += 2;
-      } else if (fmt[1] == 'z' && fmt[2] == 'u') {
-        size_t val = va_arg(ap, size_t);
-        snprintf(buf, sizeof(buf), "%lu", (unsigned long) val);
-        len += out->printer(out, buf, strlen(buf));
-        skip += 1;
-      } else if (fmt[1] == 'M') {
-        json_printf_callback_t f = va_arg(ap, json_printf_callback_t);
-        len += f(out, &ap);
-      } else if (fmt[1] == 'B') {
-        int val = va_arg(ap, int);
-        const char *str = val ? "true" : "false";
-        len += out->printer(out, str, strlen(str));
-      } else if (fmt[1] == 'H') {
-#if JSON_ENABLE_HEX
-        const char *hex = "0123456789abcdef";
-        int i, n = va_arg(ap, int);
-        const unsigned char *p = va_arg(ap, const unsigned char *);
-        len += out->printer(out, quote, 1);
-        for (i = 0; i < n; i++) {
-          len += out->printer(out, &hex[(p[i] >> 4) & 0xf], 1);
-          len += out->printer(out, &hex[p[i] & 0xf], 1);
-        }
-        len += out->printer(out, quote, 1);
-#endif /* JSON_ENABLE_HEX */
-      } else if (fmt[1] == 'V') {
-#if JSON_ENABLE_BASE64
-        const unsigned char *p = va_arg(ap, const unsigned char *);
-        int n = va_arg(ap, int);
-        len += out->printer(out, quote, 1);
-        len += b64enc(out, p, n);
-        len += out->printer(out, quote, 1);
-#endif /* JSON_ENABLE_BASE64 */
-      } else if (fmt[1] == 'Q' ||
-                 (fmt[1] == '.' && fmt[2] == '*' && fmt[3] == 'Q')) {
-        size_t l = 0;
-        const char *p;
-
-        if (fmt[1] == '.') {
-          l = (size_t) va_arg(ap, int);
-          skip += 2;
-        }
-        p = va_arg(ap, char *);
-
-        if (p == NULL) {
-          len += out->printer(out, null, 4);
-        } else {
-          if (fmt[1] == 'Q') {
-            l = strlen(p);
-          }
-          len += out->printer(out, quote, 1);
-          len += json_escape(out, p, l);
-          len += out->printer(out, quote, 1);
-        }
-      } else {
-        /*
-         * we delegate printing to the system printf.
-         * The goal here is to delegate all modifiers parsing to the system
-         * printf, as you can see below we still have to parse the format
-         * types.
-         *
-         * Currently, %s with strings longer than 20 chars will require
-         * double-buffering (an auxiliary buffer will be allocated from heap).
-         * TODO(dfrank): reimplement %s and %.*s in order to avoid that.
-         */
-
-        const char *end_of_format_specifier = "sdfFeEgGlhuIcx.*-0123456789";
-        int n = strspn(fmt + 1, end_of_format_specifier);
-        char *pbuf = buf;
-        int need_len, size = sizeof(buf);
-        char fmt2[20];
-        va_list ap_copy;
-        strncpy(fmt2, fmt,
-                n + 1 > (int) sizeof(fmt2) ? sizeof(fmt2) : (size_t) n + 1);
-        fmt2[n + 1] = '\0';
-
-        va_copy(ap_copy, ap);
-        need_len = vsnprintf(pbuf, size, fmt2, ap_copy);
-        va_end(ap_copy);
-
-        if (need_len < 0) {
-          /*
-           * Windows & eCos vsnprintf implementation return -1 on overflow
-           * instead of needed size.
-           */
-          pbuf = NULL;
-          while (need_len < 0) {
-            free(pbuf);
-            size *= 2;
-            if ((pbuf = (char *) malloc(size)) == NULL) break;
-            va_copy(ap_copy, ap);
-            need_len = vsnprintf(pbuf, size, fmt2, ap_copy);
-            va_end(ap_copy);
-          }
-        } else if (need_len >= (int) sizeof(buf)) {
-          /*
-           * resulting string doesn't fit into a stack-allocated buffer `buf`,
-           * so we need to allocate a new buffer from heap and use it
-           */
-          if ((pbuf = (char *) malloc(need_len + 1)) != NULL) {
-            va_copy(ap_copy, ap);
-            vsnprintf(pbuf, need_len + 1, fmt2, ap_copy);
-            va_end(ap_copy);
-          }
-        }
-        if (pbuf == NULL) {
-          buf[0] = '\0';
-          pbuf = buf;
-        }
-
-        /*
-         * however we need to parse the type ourselves in order to advance
-         * the va_list by the correct amount; there is no portable way to
-         * inherit the advancement made by vprintf.
-         * 32-bit (linux or windows) passes va_list by value.
-         */
-        if ((n + 1 == strlen("%" PRId64) && strcmp(fmt2, "%" PRId64) == 0) ||
-            (n + 1 == strlen("%" PRIu64) && strcmp(fmt2, "%" PRIu64) == 0)) {
-          (void) va_arg(ap, int64_t);
-        } else if (strcmp(fmt2, "%.*s") == 0) {
-          (void) va_arg(ap, int);
-          (void) va_arg(ap, char *);
-        } else {
-          switch (fmt2[n]) {
-            case 'u':
-            case 'd':
-              (void) va_arg(ap, int);
-              break;
-            case 'g':
-            case 'f':
-              (void) va_arg(ap, double);
-              break;
-            case 'p':
-              (void) va_arg(ap, void *);
-              break;
-            default:
-              /* many types are promoted to int */
-              (void) va_arg(ap, int);
-          }
-        }
-
-        len += out->printer(out, pbuf, strlen(pbuf));
-        skip = n + 1;
-
-        /* If buffer was allocated from heap, free it */
-        if (pbuf != buf) {
-          free(pbuf);
-          pbuf = NULL;
-        }
-      }
-      fmt += skip;
-    } else if (*fmt == '_' || json_isalpha(*fmt)) {
-      len += out->printer(out, quote, 1);
-      while (*fmt == '_' || json_isalpha(*fmt) || json_isdigit(*fmt)) {
-        len += out->printer(out, fmt, 1);
-        fmt++;
-      }
-      len += out->printer(out, quote, 1);
-    } else {
-      len += out->printer(out, fmt, 1);
-      fmt++;
-    }
-  }
-  va_end(ap);
-
-  return len;
-}
-
-int json_printf(struct json_out *out, const char *fmt, ...) WEAK;
-int json_printf(struct json_out *out, const char *fmt, ...) {
-  int n;
-  va_list ap;
-  va_start(ap, fmt);
-  n = json_vprintf(out, fmt, ap);
-  va_end(ap);
-  return n;
-}
-
-int json_printf_array(struct json_out *out, va_list *ap) WEAK;
-int json_printf_array(struct json_out *out, va_list *ap) {
-  int len = 0;
-  char *arr = va_arg(*ap, char *);
-  size_t i, arr_size = va_arg(*ap, size_t);
-  size_t elem_size = va_arg(*ap, size_t);
-  const char *fmt = va_arg(*ap, char *);
-  len += json_printf(out, "[", 1);
-  for (i = 0; arr != NULL && i < arr_size / elem_size; i++) {
-    union {
-      int64_t i;
-      double d;
-    } val;
-    memcpy(&val, arr + i * elem_size,
-           elem_size > sizeof(val) ? sizeof(val) : elem_size);
-    if (i > 0) len += json_printf(out, ", ");
-    if (strpbrk(fmt, "efg") != NULL) {
-      len += json_printf(out, fmt, val.d);
-    } else {
-      len += json_printf(out, fmt, val.i);
-    }
-  }
-  len += json_printf(out, "]", 1);
-  return len;
-}
-
-#ifdef _WIN32
-int cs_win_vsnprintf(char *str, size_t size, const char *format,
-                     va_list ap) WEAK;
-int cs_win_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
-  int res = _vsnprintf(str, size, format, ap);
-  va_end(ap);
-  if (res >= size) {
-    str[size - 1] = '\0';
-  }
-  return res;
-}
-
-int cs_win_snprintf(char *str, size_t size, const char *format, ...) WEAK;
-int cs_win_snprintf(char *str, size_t size, const char *format, ...) {
-  int res;
-  va_list ap;
-  va_start(ap, format);
-  res = vsnprintf(str, size, format, ap);
-  va_end(ap);
-  return res;
-}
-#endif /* _WIN32 */
-
-int json_walk(const char *json_string, int json_string_length,
-              json_walk_callback_t callback, void *callback_data) WEAK;
-int json_walk(const char *json_string, int json_string_length,
-              json_walk_callback_t callback, void *callback_data) {
-  struct frozen frozen;
-
-  memset(&frozen, 0, sizeof(frozen));
-  frozen.end = json_string + json_string_length;
-  frozen.cur = json_string;
-  frozen.callback_data = callback_data;
-  frozen.callback = callback;
-
-  TRY(json_doit(&frozen));
-
-  return frozen.cur - json_string;
-}
-
-struct scan_array_info {
-  int found;
-  char path[JSON_MAX_PATH_LEN];
-  struct json_token *token;
-};
-
-static void json_scanf_array_elem_cb(void *callback_data, const char *name,
-                                     size_t name_len, const char *path,
-                                     const struct json_token *token) {
-  struct scan_array_info *info = (struct scan_array_info *) callback_data;
-
-  (void) name;
-  (void) name_len;
-
-  if (strcmp(path, info->path) == 0) {
-    *info->token = *token;
-    info->found = 1;
-  }
-}
-
-int json_scanf_array_elem(const char *s, int len, const char *path, int idx,
-                          struct json_token *token) WEAK;
-int json_scanf_array_elem(const char *s, int len, const char *path, int idx,
-                          struct json_token *token) {
-  struct scan_array_info info;
-  info.token = token;
-  info.found = 0;
-  memset(token, 0, sizeof(*token));
-  snprintf(info.path, sizeof(info.path), "%s[%d]", path, idx);
-  json_walk(s, len, json_scanf_array_elem_cb, &info);
-  return info.found ? token->len : -1;
-}
-
-struct json_scanf_info {
-  int num_conversions;
-  char *path;
-  const char *fmt;
-  void *target;
-  void *user_data;
-  int type;
-};
-
-int json_unescape(const char *src, int slen, char *dst, int dlen) WEAK;
-int json_unescape(const char *src, int slen, char *dst, int dlen) {
-  char *send = (char *) src + slen, *dend = dst + dlen, *orig_dst = dst, *p;
-  const char *esc1 = "\"\\/bfnrt", *esc2 = "\"\\/\b\f\n\r\t";
-
-  while (src < send) {
-    if (*src == '\\') {
-      if (++src >= send) return JSON_STRING_INCOMPLETE;
-      if (*src == 'u') {
-        if (send - src < 5) return JSON_STRING_INCOMPLETE;
-        /* Here we go: this is a \u.... escape. Process simple one-byte chars */
-        if (src[1] == '0' && src[2] == '0') {
-          /* This is \u00xx character from the ASCII range */
-          if (dst < dend) *dst = hexdec(src + 3);
-          src += 4;
-        } else {
-          /* Complex \uXXXX escapes drag utf8 lib... Do it at some stage */
-          return JSON_STRING_INVALID;
-        }
-      } else if ((p = (char *) strchr(esc1, *src)) != NULL) {
-        if (dst < dend) *dst = esc2[p - esc1];
-      } else {
-        return JSON_STRING_INVALID;
-      }
-    } else {
-      if (dst < dend) *dst = *src;
-    }
-    dst++;
-    src++;
-  }
-
-  return dst - orig_dst;
-}
-
-static void json_scanf_cb(void *callback_data, const char *name,
-                          size_t name_len, const char *path,
-                          const struct json_token *token) {
-  struct json_scanf_info *info = (struct json_scanf_info *) callback_data;
-  char buf[32]; /* Must be enough to hold numbers */
-
-  (void) name;
-  (void) name_len;
-
-  if (token->ptr == NULL) {
-    /*
-     * We're not interested here in the events for which we have no value;
-     * namely, JSON_TYPE_OBJECT_START and JSON_TYPE_ARRAY_START
-     */
-    return;
-  }
-
-  if (strcmp(path, info->path) != 0) {
-    /* It's not the path we're looking for, so, just ignore this callback */
-    return;
-  }
-
-  switch (info->type) {
-    case 'B':
-      info->num_conversions++;
-      switch (sizeof(bool)) {
-        case sizeof(char):
-          *(char *) info->target = (token->type == JSON_TYPE_TRUE ? 1 : 0);
-          break;
-        case sizeof(int):
-          *(int *) info->target = (token->type == JSON_TYPE_TRUE ? 1 : 0);
-          break;
-        default:
-          /* should never be here */
-          abort();
-      }
-      break;
-    case 'M': {
-      union {
-        void *p;
-        json_scanner_t f;
-      } u = {info->target};
-      info->num_conversions++;
-      u.f(token->ptr, token->len, info->user_data);
-      break;
-    }
-    case 'Q': {
-      char **dst = (char **) info->target;
-      if (token->type == JSON_TYPE_NULL) {
-        *dst = NULL;
-      } else {
-        int unescaped_len = json_unescape(token->ptr, token->len, NULL, 0);
-        if (unescaped_len >= 0 &&
-            (*dst = (char *) malloc(unescaped_len + 1)) != NULL) {
-          info->num_conversions++;
-          if (json_unescape(token->ptr, token->len, *dst, unescaped_len) ==
-              unescaped_len) {
-            (*dst)[unescaped_len] = '\0';
-          } else {
-            free(*dst);
-            *dst = NULL;
-          }
-        }
-      }
-      break;
-    }
-    case 'H': {
-#if JSON_ENABLE_HEX
-      char **dst = (char **) info->user_data;
-      int i, len = token->len / 2;
-      *(int *) info->target = len;
-      if ((*dst = (char *) malloc(len + 1)) != NULL) {
-        for (i = 0; i < len; i++) {
-          (*dst)[i] = hexdec(token->ptr + 2 * i);
-        }
-        (*dst)[len] = '\0';
-        info->num_conversions++;
-      }
-#endif /* JSON_ENABLE_HEX */
-      break;
-    }
-    case 'V': {
-#if JSON_ENABLE_BASE64
-      char **dst = (char **) info->target;
-      int len = token->len * 4 / 3 + 2;
-      if ((*dst = (char *) malloc(len + 1)) != NULL) {
-        int n = b64dec(token->ptr, token->len, *dst);
-        (*dst)[n] = '\0';
-        *(int *) info->user_data = n;
-        info->num_conversions++;
-      }
-#endif /* JSON_ENABLE_BASE64 */
-      break;
-    }
-    case 'T':
-      info->num_conversions++;
-      *(struct json_token *) info->target = *token;
-      break;
-    default:
-      if (token->len >= (int) sizeof(buf)) break;
-      /* Before converting, copy into tmp buffer in order to 0-terminate it */
-      memcpy(buf, token->ptr, token->len);
-      buf[token->len] = '\0';
-      /* NB: Use of base 0 for %d, %ld, %u and %lu is intentional. */
-      if (info->fmt[1] == 'd' || (info->fmt[1] == 'l' && info->fmt[2] == 'd') ||
-          info->fmt[1] == 'i') {
-        char *endptr = NULL;
-        long r = strtol(buf, &endptr, 0 /* base */);
-        if (*endptr == '\0') {
-          if (info->fmt[1] == 'l') {
-            *((long *) info->target) = r;
-          } else {
-            *((int *) info->target) = (int) r;
-          }
-          info->num_conversions++;
-        }
-      } else if (info->fmt[1] == 'u' ||
-                 (info->fmt[1] == 'l' && info->fmt[2] == 'u')) {
-        char *endptr = NULL;
-        unsigned long r = strtoul(buf, &endptr, 0 /* base */);
-        if (*endptr == '\0') {
-          if (info->fmt[1] == 'l') {
-            *((unsigned long *) info->target) = r;
-          } else {
-            *((unsigned int *) info->target) = (unsigned int) r;
-          }
-          info->num_conversions++;
-        }
-      } else {
-#if !JSON_MINIMAL
-        info->num_conversions += sscanf(buf, info->fmt, info->target);
-#endif
-      }
-      break;
-  }
-}
-
-int json_vscanf(const char *s, int len, const char *fmt, va_list ap) WEAK;
-int json_vscanf(const char *s, int len, const char *fmt, va_list ap) {
-  char path[JSON_MAX_PATH_LEN] = "", fmtbuf[20];
-  int i = 0;
-  char *p = NULL;
-  struct json_scanf_info info = {0, path, fmtbuf, NULL, NULL, 0};
-
-  while (fmt[i] != '\0') {
-    if (fmt[i] == '{') {
-      strcat(path, ".");
-      i++;
-    } else if (fmt[i] == '}') {
-      if ((p = strrchr(path, '.')) != NULL) *p = '\0';
-      i++;
-    } else if (fmt[i] == '%') {
-      info.target = va_arg(ap, void *);
-      info.type = fmt[i + 1];
-      switch (fmt[i + 1]) {
-        case 'M':
-        case 'V':
-        case 'H':
-          info.user_data = va_arg(ap, void *);
-        /* FALLTHROUGH */
-        case 'B':
-        case 'Q':
-        case 'T':
-          i += 2;
-          break;
-        default: {
-          const char *delims = ", \t\r\n]}";
-          int conv_len = strcspn(fmt + i + 1, delims) + 1;
-          memcpy(fmtbuf, fmt + i, conv_len);
-          fmtbuf[conv_len] = '\0';
-          i += conv_len;
-          i += strspn(fmt + i, delims);
-          break;
-        }
-      }
-      json_walk(s, len, json_scanf_cb, &info);
-    } else if (json_isalpha(fmt[i]) || json_get_utf8_char_len(fmt[i]) > 1) {
-      char *pe;
-      const char *delims = ": \r\n\t";
-      int key_len = strcspn(&fmt[i], delims);
-      if ((p = strrchr(path, '.')) != NULL) p[1] = '\0';
-      pe = path + strlen(path);
-      memcpy(pe, fmt + i, key_len);
-      pe[key_len] = '\0';
-      i += key_len + strspn(fmt + i + key_len, delims);
-    } else {
-      i++;
-    }
-  }
-  return info.num_conversions;
-}
-
-int json_scanf(const char *str, int len, const char *fmt, ...) WEAK;
-int json_scanf(const char *str, int len, const char *fmt, ...) {
-  int result;
-  va_list ap;
-  va_start(ap, fmt);
-  result = json_vscanf(str, len, fmt, ap);
-  va_end(ap);
-  return result;
-}
-
-int json_vfprintf(const char *file_name, const char *fmt, va_list ap) WEAK;
-int json_vfprintf(const char *file_name, const char *fmt, va_list ap) {
-  int res = -1;
-  FILE *fp = fopen(file_name, "wb");
-  if (fp != NULL) {
-    struct json_out out = JSON_OUT_FILE(fp);
-    res = json_vprintf(&out, fmt, ap);
-    fputc('\n', fp);
-    fclose(fp);
-  }
-  return res;
-}
-
-int json_fprintf(const char *file_name, const char *fmt, ...) WEAK;
-int json_fprintf(const char *file_name, const char *fmt, ...) {
-  int result;
-  va_list ap;
-  va_start(ap, fmt);
-  result = json_vfprintf(file_name, fmt, ap);
-  va_end(ap);
-  return result;
-}
-
-char *json_fread(const char *path) WEAK;
-char *json_fread(const char *path) {
-  FILE *fp;
-  char *data = NULL;
-  if ((fp = fopen(path, "rb")) == NULL) {
-  } else if (fseek(fp, 0, SEEK_END) != 0) {
-    fclose(fp);
-  } else {
-    long size = ftell(fp);
-    if (size > 0 && (data = (char *) malloc(size + 1)) != NULL) {
-      fseek(fp, 0, SEEK_SET); /* Some platforms might not have rewind(), Oo */
-      if (fread(data, 1, size, fp) != (size_t) size) {
-        free(data);
-        data = NULL;
-      } else {
-        data[size] = '\0';
-      }
-    }
-    fclose(fp);
-  }
-  return data;
-}
-
-struct json_setf_data {
-  const char *json_path;
-  const char *base; /* Pointer to the source JSON string */
-  int matched;      /* Matched part of json_path */
-  int pos;          /* Offset of the mutated value begin */
-  int end;          /* Offset of the mutated value end */
-  int prev;         /* Offset of the previous token end */
-};
-
-static int get_matched_prefix_len(const char *s1, const char *s2) {
-  int i = 0;
-  while (s1[i] && s2[i] && s1[i] == s2[i]) i++;
-  return i;
-}
-
-static void json_vsetf_cb(void *userdata, const char *name, size_t name_len,
-                          const char *path, const struct json_token *t) {
-  struct json_setf_data *data = (struct json_setf_data *) userdata;
-  int off, len = get_matched_prefix_len(path, data->json_path);
-  if (t->ptr == NULL) return;
-  off = t->ptr - data->base;
-  if (len > data->matched) data->matched = len;
-
-  /*
-   * If there is no exact path match, set the mutation position to tbe end
-   * of the object or array
-   */
-  if (len < data->matched && data->pos == 0 &&
-      (t->type == JSON_TYPE_OBJECT_END || t->type == JSON_TYPE_ARRAY_END)) {
-    data->pos = data->end = data->prev;
-  }
-
-  /* Exact path match. Set mutation position to the value of this token */
-  if (strcmp(path, data->json_path) == 0 && t->type != JSON_TYPE_OBJECT_START &&
-      t->type != JSON_TYPE_ARRAY_START) {
-    data->pos = off;
-    data->end = off + t->len;
-  }
-
-  /*
-   * For deletion, we need to know where the previous value ends, because
-   * we don't know where matched value key starts.
-   * When the mutation position is not yet set, remember each value end.
-   * When the mutation position is already set, but it is at the beginning
-   * of the object/array, we catch the end of the object/array and see
-   * whether the object/array start is closer then previously stored prev.
-   */
-  if (data->pos == 0) {
-    data->prev = off + t->len; /* pos is not yet set */
-  } else if ((t->ptr[0] == '[' || t->ptr[0] == '{') && off + 1 < data->pos &&
-             off + 1 > data->prev) {
-    data->prev = off + 1;
-  }
-  (void) name;
-  (void) name_len;
-}
-
-int json_vsetf(const char *s, int len, struct json_out *out,
-               const char *json_path, const char *json_fmt, va_list ap) WEAK;
-int json_vsetf(const char *s, int len, struct json_out *out,
-               const char *json_path, const char *json_fmt, va_list ap) {
-  struct json_setf_data data;
-  memset(&data, 0, sizeof(data));
-  data.json_path = json_path;
-  data.base = s;
-  data.end = len;
-  json_walk(s, len, json_vsetf_cb, &data);
-  if (json_fmt == NULL) {
-    /* Deletion codepath */
-    json_printf(out, "%.*s", data.prev, s);
-    /* Trim comma after the value that begins at object/array start */
-    if (s[data.prev - 1] == '{' || s[data.prev - 1] == '[') {
-      int i = data.end;
-      while (i < len && json_isspace(s[i])) i++;
-      if (s[i] == ',') data.end = i + 1; /* Point after comma */
-    }
-    json_printf(out, "%.*s", len - data.end, s + data.end);
-  } else {
-    /* Modification codepath */
-    int n, off = data.matched, depth = 0;
-
-    /* Print the unchanged beginning */
-    json_printf(out, "%.*s", data.pos, s);
-
-    /* Add missing keys */
-    while ((n = strcspn(&json_path[off], ".[")) > 0) {
-      if (s[data.prev - 1] != '{' && s[data.prev - 1] != '[' && depth == 0) {
-        json_printf(out, ",");
-      }
-      if (off > 0 && json_path[off - 1] != '.') break;
-      json_printf(out, "%.*Q:", n, json_path + off);
-      off += n;
-      if (json_path[off] != '\0') {
-        json_printf(out, "%c", json_path[off] == '.' ? '{' : '[');
-        depth++;
-        off++;
-      }
-    }
-    /* Print the new value */
-    json_vprintf(out, json_fmt, ap);
-
-    /* Close brackets/braces of the added missing keys */
-    for (; off > data.matched; off--) {
-      int ch = json_path[off];
-      const char *p = ch == '.' ? "}" : ch == '[' ? "]" : "";
-      json_printf(out, "%s", p);
-    }
-
-    /* Print the rest of the unchanged string */
-    json_printf(out, "%.*s", len - data.end, s + data.end);
-  }
-  return data.end > data.pos ? 1 : 0;
-}
-
-int json_setf(const char *s, int len, struct json_out *out,
-              const char *json_path, const char *json_fmt, ...) WEAK;
-int json_setf(const char *s, int len, struct json_out *out,
-              const char *json_path, const char *json_fmt, ...) {
-  int result;
-  va_list ap;
-  va_start(ap, json_fmt);
-  result = json_vsetf(s, len, out, json_path, json_fmt, ap);
-  va_end(ap);
-  return result;
-}
-
-struct prettify_data {
-  struct json_out *out;
-  int level;
-  int last_token;
-};
-
-static void indent(struct json_out *out, int level) {
-  while (level-- > 0) out->printer(out, "  ", 2);
-}
-
-static void print_key(struct prettify_data *pd, const char *path,
-                      const char *name, int name_len) {
-  if (pd->last_token != JSON_TYPE_INVALID &&
-      pd->last_token != JSON_TYPE_ARRAY_START &&
-      pd->last_token != JSON_TYPE_OBJECT_START) {
-    pd->out->printer(pd->out, ",", 1);
-  }
-  if (path[0] != '\0') pd->out->printer(pd->out, "\n", 1);
-  indent(pd->out, pd->level);
-  if (path[0] != '\0' && path[strlen(path) - 1] != ']') {
-    pd->out->printer(pd->out, "\"", 1);
-    pd->out->printer(pd->out, name, (int) name_len);
-    pd->out->printer(pd->out, "\"", 1);
-    pd->out->printer(pd->out, ": ", 2);
-  }
-}
-
-static void prettify_cb(void *userdata, const char *name, size_t name_len,
-                        const char *path, const struct json_token *t) {
-  struct prettify_data *pd = (struct prettify_data *) userdata;
-  switch (t->type) {
-    case JSON_TYPE_OBJECT_START:
-    case JSON_TYPE_ARRAY_START:
-      print_key(pd, path, name, name_len);
-      pd->out->printer(pd->out, t->type == JSON_TYPE_ARRAY_START ? "[" : "{",
-                       1);
-      pd->level++;
-      break;
-    case JSON_TYPE_OBJECT_END:
-    case JSON_TYPE_ARRAY_END:
-      pd->level--;
-      if (pd->last_token != JSON_TYPE_INVALID &&
-          pd->last_token != JSON_TYPE_ARRAY_START &&
-          pd->last_token != JSON_TYPE_OBJECT_START) {
-        pd->out->printer(pd->out, "\n", 1);
-        indent(pd->out, pd->level);
-      }
-      pd->out->printer(pd->out, t->type == JSON_TYPE_ARRAY_END ? "]" : "}", 1);
-      break;
-    case JSON_TYPE_NUMBER:
-    case JSON_TYPE_NULL:
-    case JSON_TYPE_TRUE:
-    case JSON_TYPE_FALSE:
-    case JSON_TYPE_STRING:
-      print_key(pd, path, name, name_len);
-      if (t->type == JSON_TYPE_STRING) pd->out->printer(pd->out, "\"", 1);
-      pd->out->printer(pd->out, t->ptr, t->len);
-      if (t->type == JSON_TYPE_STRING) pd->out->printer(pd->out, "\"", 1);
-      break;
-    default:
-      break;
-  }
-  pd->last_token = t->type;
-}
-
-int json_prettify(const char *s, int len, struct json_out *out) WEAK;
-int json_prettify(const char *s, int len, struct json_out *out) {
-  struct prettify_data pd = {out, 0, JSON_TYPE_INVALID};
-  return json_walk(s, len, prettify_cb, &pd);
-}
-
-int json_prettify_file(const char *file_name) WEAK;
-int json_prettify_file(const char *file_name) {
-  int res = -1;
-  char *s = json_fread(file_name);
-  FILE *fp;
-  if (s != NULL && (fp = fopen(file_name, "wb")) != NULL) {
-    struct json_out out = JSON_OUT_FILE(fp);
-    res = json_prettify(s, strlen(s), &out);
-    if (res < 0) {
-      /* On error, restore the old content */
-      fclose(fp);
-      fp = fopen(file_name, "wb");
-      fseek(fp, 0, SEEK_SET);
-      fwrite(s, 1, strlen(s), fp);
-    } else {
-      fputc('\n', fp);
-    }
-    fclose(fp);
-  }
-  free(s);
-  return res;
-}
-
-struct next_data {
-  void *handle;            // Passed handle. Changed if a next entry is found
-  const char *path;        // Path to the iterated object/array
-  int path_len;            // Path length - optimisation
-  int found;               // Non-0 if found the next entry
-  struct json_token *key;  // Object's key
-  struct json_token *val;  // Object's value
-  int *idx;                // Array index
-};
-
-static void next_set_key(struct next_data *d, const char *name, int name_len,
-                         int is_array) {
-  if (is_array) {
-    /* Array. Set index and reset key  */
-    if (d->key != NULL) {
-      d->key->len = 0;
-      d->key->ptr = NULL;
-    }
-    if (d->idx != NULL) *d->idx = atoi(name);
-  } else {
-    /* Object. Set key and make index -1 */
-    if (d->key != NULL) {
-      d->key->ptr = name;
-      d->key->len = name_len;
-    }
-    if (d->idx != NULL) *d->idx = -1;
-  }
-}
-
-static void json_next_cb(void *userdata, const char *name, size_t name_len,
-                         const char *path, const struct json_token *t) {
-  struct next_data *d = (struct next_data *) userdata;
-  const char *p = path + d->path_len;
-  if (d->found) return;
-  if (d->path_len >= (int) strlen(path)) return;
-  if (strncmp(d->path, path, d->path_len) != 0) return;
-  if (strchr(p + 1, '.') != NULL) return; /* More nested objects - skip */
-  if (strchr(p + 1, '[') != NULL) return; /* Ditto for arrays */
-  // {OBJECT,ARRAY}_END types do not pass name, _START does. Save key.
-  if (t->type == JSON_TYPE_OBJECT_START || t->type == JSON_TYPE_ARRAY_START) {
-    next_set_key(d, name, name_len, p[0] == '[');
-  } else if (d->handle == NULL || d->handle < (void *) t->ptr) {
-    if (t->type != JSON_TYPE_OBJECT_END && t->type != JSON_TYPE_ARRAY_END) {
-      next_set_key(d, name, name_len, p[0] == '[');
-    }
-    if (d->val != NULL) *d->val = *t;
-    d->handle = (void *) t->ptr;
-    d->found = 1;
-  }
-}
-
-static void *json_next(const char *s, int len, void *handle, const char *path,
-                       struct json_token *key, struct json_token *val, int *i) {
-  struct json_token tmpval, *v = val == NULL ? &tmpval : val;
-  struct json_token tmpkey, *k = key == NULL ? &tmpkey : key;
-  int tmpidx, *pidx = i == NULL ? &tmpidx : i;
-  struct next_data data = {handle, path, (int) strlen(path), 0, k, v, pidx};
-  json_walk(s, len, json_next_cb, &data);
-  return data.found ? data.handle : NULL;
-}
-
-void *json_next_key(const char *s, int len, void *handle, const char *path,
-                    struct json_token *key, struct json_token *val) WEAK;
-void *json_next_key(const char *s, int len, void *handle, const char *path,
-                    struct json_token *key, struct json_token *val) {
-  return json_next(s, len, handle, path, key, val, NULL);
-}
-
-void *json_next_elem(const char *s, int len, void *handle, const char *path,
-                     int *idx, struct json_token *val) WEAK;
-void *json_next_elem(const char *s, int len, void *handle, const char *path,
-                     int *idx, struct json_token *val) {
-  return json_next(s, len, handle, path, NULL, val, idx);
-}
-
-static int json_sprinter(struct json_out *out, const char *str, size_t len) {
-  size_t old_len = out->u.buf.buf == NULL ? 0 : strlen(out->u.buf.buf);
-  size_t new_len = len + old_len;
-  char *p = (char *) realloc(out->u.buf.buf, new_len + 1);
-  if (p != NULL) {
-    memcpy(p + old_len, str, len);
-    p[new_len] = '\0';
-    out->u.buf.buf = p;
-  }
-  return len;
-}
-
-char *json_vasprintf(const char *fmt, va_list ap) WEAK;
-char *json_vasprintf(const char *fmt, va_list ap) {
-  struct json_out out;
-  memset(&out, 0, sizeof(out));
-  out.printer = json_sprinter;
-  json_vprintf(&out, fmt, ap);
-  return out.u.buf.buf;
-}
-
-char *json_asprintf(const char *fmt, ...) WEAK;
-char *json_asprintf(const char *fmt, ...) {
-  char *result = NULL;
-  va_list ap;
-  va_start(ap, fmt);
-  result = json_vasprintf(fmt, ap);
-  va_end(ap);
-  return result;
-}
 #ifdef MJS_MODULE_LINES
 #line 1 "src/ffi/ffi.c"
 #endif
@@ -6864,7 +2527,7 @@ int ffi_call(ffi_fn_t *func, int nargs, struct ffi_arg *res,
 #endif
 
 #include <stdio.h>
-/* Amalgamated: #include "common/str_util.h" */
+#include "common/str_util.h"
 /* Amalgamated: #include "mjs_array.h" */
 /* Amalgamated: #include "mjs_conversion.h" */
 /* Amalgamated: #include "mjs_core.h" */
@@ -7100,7 +2763,7 @@ clean:
 #line 1 "src/mjs_bcode.c"
 #endif
 
-/* Amalgamated: #include "common/cs_varint.h" */
+#include "common/cs_varint.h"
 
 /* Amalgamated: #include "mjs_internal.h" */
 /* Amalgamated: #include "mjs_bcode.h" */
@@ -7505,8 +3168,8 @@ MJS_PRIVATE int mjs_is_truthy(struct mjs *mjs, mjs_val_t v) {
 #line 1 "src/mjs_core.c"
 #endif
 
-/* Amalgamated: #include "common/cs_varint.h" */
-/* Amalgamated: #include "common/str_util.h" */
+#include "common/cs_varint.h"
+#include "common/str_util.h"
 
 /* Amalgamated: #include "mjs_bcode.h" */
 /* Amalgamated: #include "mjs_builtin.h" */
@@ -7975,8 +3638,8 @@ void mjs_mem_set_int(void *ptr, int val, int size, int bigendian) {
 #line 1 "src/mjs_exec.c"
 #endif
 
-/* Amalgamated: #include "common/cs_file.h" */
-/* Amalgamated: #include "common/cs_varint.h" */
+#include "common/cs_file.h"
+#include "common/cs_varint.h"
 
 /* Amalgamated: #include "mjs_array.h" */
 /* Amalgamated: #include "mjs_bcode.h" */
@@ -9149,7 +4812,7 @@ mjs_err_t mjs_apply(struct mjs *mjs, mjs_val_t *res, mjs_val_t func,
 #line 1 "src/mjs_ffi.c"
 #endif
 
-/* Amalgamated: #include "common/mg_str.h" */
+#include "common/mg_str.h"
 
 /* Amalgamated: #include "ffi/ffi.h" */
 /* Amalgamated: #include "mjs_core.h" */
@@ -10326,8 +5989,8 @@ void *dlsym(void *handle, const char *name) {
 
 #include <stdio.h>
 
-/* Amalgamated: #include "common/cs_varint.h" */
-/* Amalgamated: #include "common/mbuf.h" */
+#include "common/cs_varint.h"
+#include "common/mbuf.h"
 
 /* Amalgamated: #include "mjs_core.h" */
 /* Amalgamated: #include "mjs_ffi.h" */
@@ -10861,8 +6524,8 @@ MJS_PRIVATE int gc_check_ptr(const struct gc_arena *a, const void *ptr) {
 #line 1 "src/mjs_json.c"
 #endif
 
-/* Amalgamated: #include "common/str_util.h" */
-/* Amalgamated: #include "frozen.h" */
+#include "common/str_util.h"
+#include "frozen.h"
 /* Amalgamated: #include "mjs_array.h" */
 /* Amalgamated: #include "mjs_internal.h" */
 /* Amalgamated: #include "mjs_conversion.h" */
@@ -11443,7 +7106,7 @@ int main(int argc, char *argv[]) {
 /* Amalgamated: #include "mjs_string.h" */
 /* Amalgamated: #include "mjs_util.h" */
 
-/* Amalgamated: #include "common/mg_str.h" */
+#include "common/mg_str.h"
 
 MJS_PRIVATE mjs_val_t mjs_object_to_value(struct mjs_object *o) {
   if (o == NULL) {
@@ -11831,7 +7494,7 @@ mjs_val_t mjs_struct_to_obj(struct mjs *mjs, const void *base,
 #line 1 "src/mjs_parser.c"
 #endif
 
-/* Amalgamated: #include "common/cs_varint.h" */
+#include "common/cs_varint.h"
 
 /* Amalgamated: #include "mjs_bcode.h" */
 /* Amalgamated: #include "mjs_core.h" */
@@ -13018,8 +8681,8 @@ MJS_PRIVATE void mjs_op_isnan(struct mjs *mjs) {
 #endif
 
 /* Amalgamated: #include "mjs_string.h" */
-/* Amalgamated: #include "common/cs_varint.h" */
-/* Amalgamated: #include "common/mg_str.h" */
+#include "common/cs_varint.h"
+#include "common/mg_str.h"
 /* Amalgamated: #include "mjs_conversion.h" */
 /* Amalgamated: #include "mjs_core.h" */
 /* Amalgamated: #include "mjs_internal.h" */
@@ -13616,7 +9279,7 @@ MJS_PRIVATE void embed_string(struct mbuf *m, size_t offset, const char *p,
 #include <stdlib.h>
 #include <string.h>
 
-/* Amalgamated: #include "common/cs_dbg.h" */
+#include "common/cs_dbg.h"
 /* Amalgamated: #include "mjs_tok.h" */
 
 MJS_PRIVATE void pinit(const char *file_name, const char *buf,
@@ -13866,8 +9529,8 @@ MJS_PRIVATE int pnext(struct pstate *p) {
 #line 1 "src/mjs_util.c"
 #endif
 
-/* Amalgamated: #include "common/cs_varint.h" */
-/* Amalgamated: #include "frozen.h" */
+#include "common/cs_varint.h"
+#include "frozen.h"
 /* Amalgamated: #include "mjs_array.h" */
 /* Amalgamated: #include "mjs_bcode.h" */
 /* Amalgamated: #include "mjs_core.h" */

--- a/src/mjs_core.c
+++ b/src/mjs_core.c
@@ -12,7 +12,6 @@
 #include "mjs_exec.h"
 #include "mjs_ffi.h"
 #include "mjs_internal.h"
-#include "mjs_license.h"
 #include "mjs_object.h"
 #include "mjs_primitive.h"
 #include "mjs_string.h"

--- a/src/mjs_core_public.h
+++ b/src/mjs_core_public.h
@@ -15,7 +15,6 @@ typedef unsigned char uint8_t;
 #endif
 #include <stdio.h>
 #include <stddef.h>
-#include "mjs_license.h"
 #include "mjs_features.h"
 
 #if defined(__cplusplus)

--- a/src/mjs_sources.mk
+++ b/src/mjs_sources.mk
@@ -1,13 +1,13 @@
-COMMON = common
-FROZEN = frozen
+COMMON_SOURCES = \
+          common/cs_dbg.c \
+          common/cs_file.c \
+          common/cs_varint.c \
+          common/mbuf.c \
+          common/mg_str.c \
+          common/str_util.c \
+          frozen/frozen.c
 
-SOURCES = $(COMMON)/cs_dbg.c \
-          $(COMMON)/cs_file.c \
-          $(COMMON)/cs_varint.c \
-          $(COMMON)/mbuf.c \
-          $(COMMON)/mg_str.c \
-          $(COMMON)/str_util.c \
-          $(FROZEN)/frozen.c \
+MJS_SOURCES = \
           ffi/ffi.c \
           mjs_array.c \
           mjs_bcode.c \
@@ -27,41 +27,43 @@ SOURCES = $(COMMON)/cs_dbg.c \
           mjs_tok.c \
           mjs_util.c
 
-HEADERS = $(COMMON)/mbuf.h \
-          $(COMMON)/cs_dbg.h \
-          $(COMMON)/cs_file.h \
-          $(COMMON)/cs_time.h \
-          $(COMMON)/cs_varint.h \
-          $(COMMON)/str_util.h \
-          $(COMMON)/mg_mem.h \
-          $(COMMON)/platform.h \
-          $(FROZEN)/frozen.h \
+MJS_PUBLIC_HEADERS = \
+          mjs_array_public.h \
+          mjs_core_public.h \
+          mjs_exec_public.h \
+          mjs_ffi_public.h \
+          mjs_object_public.h \
+          mjs_primitive_public.h \
+          mjs_string_public.h \
+          mjs_util_public.h
+
+HEADERS = common/mbuf.h \
+          common/cs_dbg.h \
+          common/cs_file.h \
+          common/cs_time.h \
+          common/cs_varint.h \
+          common/str_util.h \
+          common/mg_mem.h \
+          common/platform.h \
+          frozen/frozen.h \
           ffi/ffi.h \
           mjs_array.h \
-          mjs_array_public.h \
           mjs_bcode.h \
           mjs_builtin.h \
           mjs_conversion.h \
           mjs_core.h \
-          mjs_core_public.h \
           mjs_dataview.h \
           mjs_exec.h \
-          mjs_exec_public.h \
           mjs_features.h \
           mjs_ffi.h \
-          mjs_ffi_public.h \
           mjs_gc.h \
           mjs_internal.h \
           mjs_json.h \
           mjs_license.h \
           mjs_mm.h \
           mjs_object.h \
-          mjs_object_public.h \
           mjs_parser.h \
           mjs_primitive.h \
-          mjs_primitive_public.h \
           mjs_string.h \
-          mjs_string_public.h \
           mjs_tok.h \
-          mjs_util.h \
-          mjs_util_public.h
+          mjs_util.h

--- a/tools/amalgam.py
+++ b/tools/amalgam.py
@@ -12,17 +12,6 @@
 # header that depends on it. All headers will always be emitted before the
 # source files.
 #
-# The embedded include files usually contain private internals.
-# However sometimes it's necessary for some other tools or for advanced users
-# to have access to internal definitions. One such example is the generated
-# C source containing frozen heap. The amalgamation script will allow users
-# to include the amalgamated C file and cause extract only the internal headers:
-#
-#     #define NS_EXPORT_INTERNAL_HEADERS
-#     #include "v7.c"
-#
-# Where `NS` can be overridden via the --prefix flag.
-# This feature can be enabled with the --exportable-headers, and basically
 # all it does is to wrap the C body in a preprocessor guard.
 #
 # TODO(mkm): make it work also for mongoose where we also generate
@@ -32,6 +21,7 @@
 #
 
 import argparse
+import fnmatch
 import io
 import re
 import sys
@@ -42,7 +32,7 @@ parser.add_argument('--prefix', default="NS",
                     help='prefix for MODULE_LINES guard')
 parser.add_argument('--srcdir', default=".", help='source dir')
 parser.add_argument('--ignore', default="",
-                    help='comma separated list of files to not amalgam')
+                    help='comma separated list of include files to leave alone')
 # hack, teach amalgam to render the LICENSE file instead
 parser.add_argument('--first', type=str, help='put this file in first position.'
                     ' Usually contains licensing info')
@@ -51,12 +41,12 @@ parser.add_argument('--public-header', dest="public",
                     ' included at the beginning of the file')
 parser.add_argument('--autoinc', action='store_true',
                     help='automatically embed include files')
+parser.add_argument('--autoinc-ignore', default="",
+                    help='comma separated list of includes to not amalgam')
 parser.add_argument('--strict', action='store_true',
                     help='fail loudly if an include file cannot be resolved')
 parser.add_argument('--norel', action='store_true',
                     help="do not try to compute a friendly relative path")
-parser.add_argument('--exportable-headers', dest="export", action='store_true',
-                    help='allow exporting internal headers')
 parser.add_argument('-I', default=['.'], dest='include_path', help='include path', action='append')
 parser.add_argument('sources', nargs='*', help='sources')
 parser.add_argument('--license', dest="license", help='License file')
@@ -71,20 +61,39 @@ class File(object):
     def emit(self):
         print('%s' % self.buf.getvalue(), end='')
 
+    def __repr__(self):
+        if self.parent_name:
+            return '(%s included from %s)' % (self.name, self.parent_name)
+        return '(%s)' % self.name
+
 
 args = parser.parse_args()
 
-sources = []
 includes = []
 
 already_included = set()
 
-ignore_files = [i.strip() for i in args.ignore.split(',')]
+ignore_patterns = [i.strip() for i in args.ignore.split(',')]
+autoinc_ignore_patterns = [i.strip() for i in args.autoinc_ignore.split(',')]
 
-def should_ignore(name, parent_name):
-    return (name in already_included
-            or not (args.strict or os.path.exists(resolve(name, parent_name)))
-            or name in ignore_files)
+
+def should_ignore(name):
+    for p in ignore_patterns:
+        if fnmatch.fnmatch(name, p):
+            return True
+    return False
+
+
+def should_ignore_autoinc(name, parent_name):
+    if name in already_included:
+        return True
+    if not (args.strict or os.path.exists(resolve(name, parent_name))):
+        return True
+    for p in autoinc_ignore_patterns:
+        if fnmatch.fnmatch(name, p):
+            return True
+    return False
+
 
 def resolve(path, parent_name):
     path_from_parent = None
@@ -106,6 +115,7 @@ def resolve(path, parent_name):
         p = os.path.realpath(p).replace('%s%s' % (os.getcwd(), os.sep), '')
     return p.replace(os.sep, '/')
 
+
 def emit_line_directive(out, name, parent_name):
     print ('''#ifdef %(prefix)s_MODULE_LINES
 #line 1 "%(name)s"
@@ -113,6 +123,7 @@ def emit_line_directive(out, name, parent_name):
     prefix = args.prefix,
     name = resolve(name, parent_name),
 ), file=out)
+
 
 def emit_body(out, name, parent_name):
     resolved_name = resolve(name, parent_name)
@@ -139,13 +150,14 @@ def emit_body(out, name, parent_name):
 
             match = re.match('( *#include "(.*)")', l)
             if match:
-                all, path_to_include = match.groups()
-                if args.autoinc:
-                    if not should_ignore(path_to_include, parent_name):
-                        already_included.add(path_to_include)
-                        includes.append(File(path_to_include, resolved_name))
-                print('/* Amalgamated: %s */' % all, file=out)
-            else:
+                all_match, path_to_include = match.groups()
+                if not should_ignore(path_to_include):
+                    l = '/* Amalgamated: %s */\n' % all_match
+                    if args.autoinc:
+                        if not should_ignore_autoinc(path_to_include, parent_name):
+                            already_included.add(path_to_include)
+                            includes.append(File(path_to_include, resolved_name))
+            if l is not None:
                 out.write(l)
 
 
@@ -153,23 +165,31 @@ def emit_file(out, name, parent_name):
     emit_line_directive(out, name, parent_name)
     emit_body(out, name, parent_name)
 
-for i in args.sources:
-    sources.append(File(i, None))
+
+sources = []
+
+for f in args.sources:
+    for p in ignore_patterns:
+        if fnmatch.fnmatch(f, p):
+            break
+    else:
+        sources.append(File(f, None))
+
+parts = includes + sources
 
 if args.first:
     for inc in reversed(args.first.split(',')):
-        for i, f in enumerate(includes):
+        for i, f in enumerate(parts):
             if f.name == inc:
-                del includes[i]
-                includes.insert(0, f)
+                del parts[i]
+                parts.insert(0, f)
                 break
 
-# emitting
+# emit
 
 if sys.platform == "win32":
     import os, msvcrt
     msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-
 
 if args.license:
     with open(args.license) as f:
@@ -178,12 +198,5 @@ if args.license:
 if args.public:
     print('#include "%s"' % args.public)
 
-for i in includes:
-    i.emit()
-
-if args.export:
-    print('#ifndef %s_EXPORT_INTERNAL_HEADERS' % (args.prefix,))
-for i in sources:
-    i.emit()
-if args.export:
-    print('#endif /* %s_EXPORT_INTERNAL_HEADERS */' % (args.prefix,))
+for f in parts:
+    f.emit()


### PR DESCRIPTION
A variant that does not embed all the "common" stuff, shared between
mjs, mongoose and mongoose-os.

Also remove public headers from mjs.c (already present in mjs.h) and add
license text at the top of the files.

Remove MJS_EXPORT_INTERNAL_HEADERS, it's not used.