### PR TITLE
Don't use #define CS_ENABLE_STRDUP defined().

### DIFF
--- a/mjs.c
+++ b/mjs.c
@@ -1145,7 +1145,9 @@ int gettimeofday(struct timeval *tp, void *tzp);
 /*
  * ARM C Compiler doesn't have strdup, so we provide it
  */
-#define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
+#define CS_ENABLE_STRDUP 1
+#endif
 
 #endif /* CS_PLATFORM == CS_P_NRF51 */
 #endif /* CS_COMMON_PLATFORMS_PLATFORM_NRF51_H_ */
@@ -1189,7 +1191,9 @@ int gettimeofday(struct timeval *tp, void *tzp);
 /*
  * ARM C Compiler doesn't have strdup, so we provide it
  */
-#define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
+#define CS_ENABLE_STRDUP 1
+#endif
 
 #endif /* CS_PLATFORM == CS_P_NRF52 */
 #endif /* CS_COMMON_PLATFORMS_PLATFORM_NRF52_H_ */

--- a/src/common/platforms/platform_nrf51.h
+++ b/src/common/platforms/platform_nrf51.h
@@ -48,7 +48,9 @@ int gettimeofday(struct timeval *tp, void *tzp);
 /*
  * ARM C Compiler doesn't have strdup, so we provide it
  */
-#define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
+#define CS_ENABLE_STRDUP 1
+#endif
 
 #endif /* CS_PLATFORM == CS_P_NRF51 */
 #endif /* CS_COMMON_PLATFORMS_PLATFORM_NRF51_H_ */

--- a/src/common/platforms/platform_nrf52.h
+++ b/src/common/platforms/platform_nrf52.h
@@ -51,7 +51,9 @@
 /*
  * ARM C Compiler doesn't have strdup, so we provide it
  */
-#define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
+#define CS_ENABLE_STRDUP 1
+#endif
 
 #endif /* CS_PLATFORM == CS_P_NRF52 */
 #endif /* CS_COMMON_PLATFORMS_PLATFORM_NRF52_H_ */


### PR DESCRIPTION
A simple PR to suppress a warning:

```
warning: mjs/mjs.c:1949:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
warning: #if CS_ENABLE_STRDUP
warning:     ^
warning: mjs/mjs.c:1192:26: note: expanded from macro 'CS_ENABLE_STRDUP'
warning: #define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
warning:                          ^
warning: mjs/mjs.c:4598:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
warning: #if CS_ENABLE_STRDUP
warning:     ^
warning: mjs/mjs.c:1192:26: note: expanded from macro 'CS_ENABLE_STRDUP'
warning: #define CS_ENABLE_STRDUP defined(__ARMCC_VERSION)
```

Macro expansion producing 'defined' has undefined behavior.

As explained here:

https://stackoverflow.com/questions/42074035/how-to-deal-with-clangs-3-9-wexpansion-to-defined-warning?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa